### PR TITLE
fix: CORS를 설정한 WebConfig를 빈으로 등록

### DIFF
--- a/backend/src/main/java/com/easypeach/shroop/infra/config/WebConfig.java
+++ b/backend/src/main/java/com/easypeach/shroop/infra/config/WebConfig.java
@@ -1,8 +1,10 @@
 package com.easypeach.shroop.infra.config;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@Configuration
 public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {


### PR DESCRIPTION
## 🤷 구현한 기능
WebConfig를 스프링 빈으로 등록

## 🖊️ 추가 설명

## 📄 참고 사항
