### PR TITLE
Fix: 구매하기 버튼 영역 확장

### DIFF
--- a/frontend/src/views/ProductDetailsView.vue
+++ b/frontend/src/views/ProductDetailsView.vue
@@ -92,11 +92,12 @@
               <span class="font-weight-bold pb-1">{{ likeCount }}</span>
             </v-btn>
           </v-btn-toggle>
-          <v-btn variant="outlined">
-            <router-link :to="`/purchase/${$route.params.id}`">
-              구매하기
-            </router-link></v-btn
+          <v-btn
+            variant="outlined"
+            @click="() => $router.push(`/purchase/${$route.params.id}`)"
           >
+            구매하기
+          </v-btn>
         </v-card-actions>
       </div>
     </div>


### PR DESCRIPTION
## 🤷 구현한 기능
구매하기 버튼의 클릭영역을 확장
## 🖊️ 추가 설명

## 📄 참고 사항
