### PR TITLE
Feat: 결제 기능 구현

### DIFF
--- a/backend/src/main/java/com/easypeach/shroop/ShroopApplication.java
+++ b/backend/src/main/java/com/easypeach/shroop/ShroopApplication.java
@@ -2,8 +2,10 @@ package com.easypeach.shroop;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ShroopApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/easypeach/shroop/modules/member/domain/Member.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/domain/Member.java
@@ -75,5 +75,9 @@ public class Member {
 		return member;
 	}
 
+	public void updateMember(Long updatedPoint) {
+		this.point = updatedPoint;
+	}
+
 }
 

--- a/backend/src/main/java/com/easypeach/shroop/modules/member/domain/MemberRepository.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/domain/MemberRepository.java
@@ -3,11 +3,15 @@ package com.easypeach.shroop.modules.member.domain;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsByLoginId(String loginId);
 
 	boolean existsByNickname(String nickname);
 
 	Optional<Member> findByLoginId(String loginId);
+
+	Long findPointById(Long id);
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/member/domain/MemberRepository.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/domain/MemberRepository.java
@@ -12,6 +12,4 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsByNickname(String nickname);
 
 	Optional<Member> findByLoginId(String loginId);
-
-	Long findPointById(Long id);
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/member/service/MemberService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/service/MemberService.java
@@ -1,4 +1,22 @@
 package com.easypeach.shroop.modules.member.service;
 
+import org.springframework.stereotype.Service;
+
+import com.easypeach.shroop.modules.member.domain.Member;
+import com.easypeach.shroop.modules.member.domain.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class MemberService {
+	private final MemberRepository memberRepository;
+
+	public Member findById(Long memberId) {
+		return memberRepository.findById(memberId).get();
+	}
+
+	public void saveMember(Member member) {
+		memberRepository.save(member);
+	}
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/member/service/MemberService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/service/MemberService.java
@@ -12,11 +12,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 	private final MemberRepository memberRepository;
 
-	public Member findById(Long memberId) {
+	public Member findById(final Long memberId) {
 		return memberRepository.findById(memberId).get();
-	}
-
-	public void saveMember(Member member) {
-		memberRepository.save(member);
 	}
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/product/domain/Product.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/product/domain/Product.java
@@ -20,8 +20,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import com.easypeach.shroop.modules.member.domain.Member;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import lombok.Getter;
+
 @EntityListeners(AuditingEntityListener.class)
 @Entity
+@Getter
 public class Product {
 
 	@Id
@@ -47,7 +50,7 @@ public class Product {
 	private String brand;
 
 	@Column(nullable = false)
-	private int price;
+	private Long price;
 
 	@Column(name = "is_checked_delivery_fee", nullable = false)
 	private boolean isCheckedDeliveryFee;

--- a/backend/src/main/java/com/easypeach/shroop/modules/product/domain/Product.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/product/domain/Product.java
@@ -67,7 +67,8 @@ public class Product {
 
 	@Column(name = "sale_reason", length = 255, nullable = false)
 	private String saleReason;
-
+	
+	@Enumerated(EnumType.STRING)
 	@Column(name = "status", nullable = false)
 	private ProductStatus productStatus;
 

--- a/backend/src/main/java/com/easypeach/shroop/modules/product/domain/ProductRepository.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/product/domain/ProductRepository.java
@@ -1,4 +1,9 @@
 package com.easypeach.shroop.modules.product.domain;
 
-public class ProductRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/product/service/ProductService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/product/service/ProductService.java
@@ -1,4 +1,19 @@
 package com.easypeach.shroop.modules.product.service;
 
+import org.springframework.stereotype.Service;
+
+import com.easypeach.shroop.modules.product.domain.Product;
+import com.easypeach.shroop.modules.product.domain.ProductRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class ProductService {
+	private final ProductRepository productRepository;
+
+	public Product findByProductId(Long productId) {
+		return productRepository.getById(productId);
+	}
+
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/product/service/ProductService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/product/service/ProductService.java
@@ -13,7 +13,7 @@ public class ProductService {
 	private final ProductRepository productRepository;
 
 	public Product findByProductId(Long productId) {
-		return productRepository.getById(productId);
+		return productRepository.findById(productId).get();
 	}
 
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/TransactionController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/TransactionController.java
@@ -1,4 +1,35 @@
 package com.easypeach.shroop.modules.transaction.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.easypeach.shroop.modules.auth.support.LoginMemberId;
+import com.easypeach.shroop.modules.member.domain.Member;
+import com.easypeach.shroop.modules.member.service.MemberService;
+import com.easypeach.shroop.modules.product.domain.Product;
+import com.easypeach.shroop.modules.product.service.ProductService;
+import com.easypeach.shroop.modules.transaction.dto.request.TransactionInfoResponse;
+import com.easypeach.shroop.modules.transaction.service.TransactionService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/buying")
 public class TransactionController {
+	private final ProductService productService;
+	private final MemberService memberService;
+	private final TransactionService transactionService;
+
+	@GetMapping("/{productId}")
+	public TransactionInfoResponse getBuyingForm(@PathVariable Long productId, @LoginMemberId Long memberId) {
+
+		Product product = productService.findByProductId(productId);
+		Member member = memberService.findById(memberId);
+		return new TransactionInfoResponse(product.getTitle(),
+			product.getPrice(), member.getPoint());
+	}
+
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/TransactionController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/TransactionController.java
@@ -1,7 +1,10 @@
 package com.easypeach.shroop.modules.transaction.controller;
 
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,7 +13,11 @@ import com.easypeach.shroop.modules.member.domain.Member;
 import com.easypeach.shroop.modules.member.service.MemberService;
 import com.easypeach.shroop.modules.product.domain.Product;
 import com.easypeach.shroop.modules.product.service.ProductService;
+import com.easypeach.shroop.modules.transaction.domain.Transaction;
+import com.easypeach.shroop.modules.transaction.domain.TransactionStatus;
+import com.easypeach.shroop.modules.transaction.dto.request.TransactionCreateRequest;
 import com.easypeach.shroop.modules.transaction.dto.request.TransactionInfoResponse;
+import com.easypeach.shroop.modules.transaction.dto.response.TransactionCreatedResponse;
 import com.easypeach.shroop.modules.transaction.service.TransactionService;
 
 import lombok.RequiredArgsConstructor;
@@ -32,4 +39,25 @@ public class TransactionController {
 			product.getPrice(), member.getPoint());
 	}
 
+	@Transactional
+	@PostMapping("/{productId}")
+	public TransactionCreatedResponse buyingProduct(@RequestBody TransactionCreateRequest transactionCreateRequest,
+		@PathVariable Long productId, @LoginMemberId Long memberId) {
+
+		Product product = productService.findByProductId(productId);
+		Member buyer = memberService.findById(memberId);
+		Transaction transaction = Transaction.createTransaction(buyer, product.getSeller(), product,
+			TransactionStatus.TRANSACTION_PROGRESS, transactionCreateRequest.getBuyerName(),
+			transactionCreateRequest.getBuyerLocation(),
+			transactionCreateRequest.getBuyerPhoneNumber());
+		transactionService.saveTransaction(transaction);
+
+		long updatedPoint = buyer.getPoint() - product.getPrice();
+		buyer.updateMember(updatedPoint);
+
+		return new TransactionCreatedResponse(transaction.getId(),
+			product.getTitle(),
+			product.getPrice(), transactionCreateRequest.getBuyerName(), transactionCreateRequest.getBuyerLocation(),
+			transactionCreateRequest.getBuyerPhoneNumber());
+	}
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/TransactionController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/TransactionController.java
@@ -14,7 +14,6 @@ import com.easypeach.shroop.modules.member.service.MemberService;
 import com.easypeach.shroop.modules.product.domain.Product;
 import com.easypeach.shroop.modules.product.service.ProductService;
 import com.easypeach.shroop.modules.transaction.domain.Transaction;
-import com.easypeach.shroop.modules.transaction.domain.TransactionStatus;
 import com.easypeach.shroop.modules.transaction.dto.request.TransactionCreateRequest;
 import com.easypeach.shroop.modules.transaction.dto.request.TransactionInfoResponse;
 import com.easypeach.shroop.modules.transaction.dto.response.TransactionCreatedResponse;
@@ -35,6 +34,7 @@ public class TransactionController {
 
 		Product product = productService.findByProductId(productId);
 		Member member = memberService.findById(memberId);
+		
 		return new TransactionInfoResponse(product.getTitle(),
 			product.getPrice(), member.getPoint());
 	}
@@ -46,18 +46,14 @@ public class TransactionController {
 
 		Product product = productService.findByProductId(productId);
 		Member buyer = memberService.findById(memberId);
-		Transaction transaction = Transaction.createTransaction(buyer, product.getSeller(), product,
-			TransactionStatus.TRANSACTION_PROGRESS, transactionCreateRequest.getBuyerName(),
-			transactionCreateRequest.getBuyerLocation(),
-			transactionCreateRequest.getBuyerPhoneNumber());
-		transactionService.saveTransaction(transaction);
 
-		long updatedPoint = buyer.getPoint() - product.getPrice();
-		buyer.updateMember(updatedPoint);
+		Transaction transaction = transactionService.saveTransaction(product, buyer, transactionCreateRequest);
+		transactionService.subtractPoint(product, buyer);
 
 		return new TransactionCreatedResponse(transaction.getId(),
 			product.getTitle(),
 			product.getPrice(), transactionCreateRequest.getBuyerName(), transactionCreateRequest.getBuyerLocation(),
 			transactionCreateRequest.getBuyerPhoneNumber());
 	}
+
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/domain/Delivery.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/domain/Delivery.java
@@ -15,7 +15,7 @@ public class Delivery {
 
 	@Column(name = "tracking_number", unique = true, nullable = false)
 	private Long trackingNumber;
-
-	@Column(name = "location", length = 255, nullable = false)
-	private String location;
+	
+	@Column(name = "parcel", length = 255, nullable = false)
+	private String parcel;
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/domain/Transaction.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/domain/Transaction.java
@@ -1,6 +1,6 @@
 package com.easypeach.shroop.modules.transaction.domain;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -18,8 +18,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import com.easypeach.shroop.modules.member.domain.Member;
 import com.easypeach.shroop.modules.product.domain.Product;
 
+import lombok.Getter;
+
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@Getter
 public class Transaction {
 
 	@Id
@@ -39,17 +42,38 @@ public class Transaction {
 	private Product product;
 
 	@OneToOne
-	@JoinColumn(name = "delivery_id", nullable = false)
+	@JoinColumn(name = "delivery_id")
 	private Delivery delivery;
-
-	@Column(name = "payment_date")
-	private LocalDate paymentDate;
 
 	@Column(nullable = false)
 	private TransactionStatus status;
 
+	@Column(name = "buyer_name", length = 255, nullable = false)
+	private String buyerName;
+
+	@Column(name = "buyer_phone_number", length = 255, nullable = false)
+	private String buyerPhoneNumber;
+
+	@Column(name = "buyer_location", length = 255, nullable = false)
+	private String buyerLocation;
+
 	@Column(name = "create_date")
 	@CreatedDate
-	private LocalDate createDate;
+	private LocalDateTime createDate;
 
+	public static Transaction createTransaction(final Member buyer, final Member seller, final Product product,
+		final TransactionStatus status, final String buyerName, final String buyerPhoneNumber,
+		final String buyerLocation
+	) {
+		Transaction transaction = new Transaction();
+		transaction.buyer = buyer;
+		transaction.seller = seller;
+		transaction.product = product;
+		transaction.status = status;
+		transaction.buyerName = buyerName;
+		transaction.buyerPhoneNumber = buyerPhoneNumber;
+		transaction.buyerLocation = buyerLocation;
+
+		return transaction;
+	}
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/domain/TransactionRepository.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/domain/TransactionRepository.java
@@ -1,4 +1,8 @@
 package com.easypeach.shroop.modules.transaction.domain;
 
-public class TransactionRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/domain/TransactionStatus.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/domain/TransactionStatus.java
@@ -1,4 +1,5 @@
 package com.easypeach.shroop.modules.transaction.domain;
 
 public enum TransactionStatus {
+	TRANSACTION_PROGRESS, TRANSACTION_COMPLETE, RETURN_REQUEST, RETURN_PROGRESS, RETURN_COMPLETE, MEDIATE_REQUEST
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/dto/request/TransactionInfoResponse.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/dto/request/TransactionInfoResponse.java
@@ -7,8 +7,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class TransactionCreateRequest {
-	private String buyerName;
-	private String buyerPhoneNumber;
-	private String buyerLocation;
+public class TransactionInfoResponse {
+	private String title;
+	private Long price;
+	private Long point;
+
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/dto/response/TransactionCreatedResponse.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/dto/response/TransactionCreatedResponse.java
@@ -1,4 +1,18 @@
 package com.easypeach.shroop.modules.transaction.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class TransactionCreatedResponse {
+	private Long transactionId;
+	private String productTitle;
+	private Long productPrice;
+	private String buyerName;
+	private String buyerPhoneName;
+	private String buyerLocation;
+
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/service/TransactionService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/service/TransactionService.java
@@ -1,4 +1,18 @@
 package com.easypeach.shroop.modules.transaction.service;
 
+import org.springframework.stereotype.Service;
+
+import com.easypeach.shroop.modules.transaction.domain.Transaction;
+import com.easypeach.shroop.modules.transaction.domain.TransactionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class TransactionService {
+	private final TransactionRepository transactionRepository;
+
+	public void saveTransaction(Transaction transaction) {
+		transactionRepository.save(transaction);
+	}
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/service/TransactionService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/service/TransactionService.java
@@ -2,8 +2,14 @@ package com.easypeach.shroop.modules.transaction.service;
 
 import org.springframework.stereotype.Service;
 
+import com.easypeach.shroop.modules.member.domain.Member;
+import com.easypeach.shroop.modules.member.service.MemberService;
+import com.easypeach.shroop.modules.product.domain.Product;
+import com.easypeach.shroop.modules.product.service.ProductService;
 import com.easypeach.shroop.modules.transaction.domain.Transaction;
 import com.easypeach.shroop.modules.transaction.domain.TransactionRepository;
+import com.easypeach.shroop.modules.transaction.domain.TransactionStatus;
+import com.easypeach.shroop.modules.transaction.dto.request.TransactionCreateRequest;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,8 +17,20 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TransactionService {
 	private final TransactionRepository transactionRepository;
+	private final ProductService productService;
+	private final MemberService memberService;
 
-	public void saveTransaction(Transaction transaction) {
-		transactionRepository.save(transaction);
+	public Transaction saveTransaction(Product product, Member buyer,
+		TransactionCreateRequest transactionCreateRequest) {
+		Transaction transaction = Transaction.createTransaction(buyer, product.getSeller(), product,
+			TransactionStatus.TRANSACTION_PROGRESS, transactionCreateRequest.getBuyerName(),
+			transactionCreateRequest.getBuyerLocation(),
+			transactionCreateRequest.getBuyerPhoneNumber());
+		return transactionRepository.save(transaction);
+	}
+
+	public void subtractPoint(Product product, Member buyer) {
+		long updatedPoint = buyer.getPoint() - product.getPrice();
+		buyer.updateMember(updatedPoint);
 	}
 }


### PR DESCRIPTION
## 🤷 구현한 기능
- 결제 페이지 조회
- 결제 API 구현
## 🖊️ 추가 설명
- GET 요청 시 상품의 제목, 가격, 고객의 포인트를 Resoponse로 제공합니다.
- POST 요청 시 거래를 DB에 저장하고, 고객의 포인트를 차감한 뒤, 결제 완료 페이지에 보여줄 데이터들을 제공합니다. 
## 📄 참고 사항
