### PR TITLE
Design: 구매내역 상세 페이지  UI 구현

### DIFF
--- a/frontend/src/layouts/default/AppBar.vue
+++ b/frontend/src/layouts/default/AppBar.vue
@@ -35,6 +35,7 @@
             <li>
               <router-link to="/login">로그인</router-link>
             </li>
+            <li>로그아웃</li>
             <li>
               <router-link to="/signup">회원가입</router-link>
             </li>

--- a/frontend/src/layouts/default/AppBar.vue
+++ b/frontend/src/layouts/default/AppBar.vue
@@ -39,7 +39,7 @@
               <router-link to="/signup">회원가입</router-link>
             </li>
             <li>
-              <router-link to="/mypage">마이페이지</router-link>
+              <router-link to="/mypage/0">마이페이지</router-link>
             </li>
           </ul>
         </v-menu>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -12,6 +12,7 @@ import EditProileView from "@/views/EditProileView.vue";
 import ProductsView from "@/views/ProductsView.vue";
 import PurchaseRequestView from "@/views/PurchaseRequestView.vue";
 import DeliveryRegistView from "@/views/DeliveryRegistView.vue";
+import PurchaseCompleteView from "@/views/PurchaseCompleteView.vue";
 
 const routes = [
   {
@@ -34,7 +35,10 @@ const routes = [
         component: SignupView,
       },
       {
-        path: "/mypage",
+        path: "/mypage/:index",
+        props: (route) => {
+          /^[0-2]$/.test(route.params.param) ? route.params.param : "0";
+        },
         name: "Mypage",
         component: MypageView,
       },
@@ -77,6 +81,11 @@ const routes = [
         path: "/purchase/:id(\\d+)",
         name: "Purchase",
         component: PurchaseRequestView,
+      },
+      {
+        path: "/purchaseComplete/:id(\\d+)",
+        name: "PurchaseComplete",
+        component: PurchaseCompleteView,
       },
       {
         path: "/deliveryRegist/:id(\\d+)",

--- a/frontend/src/views/MypageView.vue
+++ b/frontend/src/views/MypageView.vue
@@ -120,6 +120,7 @@
 
 <script setup>
 import { ref } from "vue";
+import { useRoute } from "vue-router";
 import { useDisplay } from "vuetify";
 import ContentLayout from "@/layouts/ContentLayout.vue";
 import basicProfile from "@/assets/image/basicProfile.jpeg";
@@ -129,9 +130,11 @@ import MiniButton from "@/components/Button/MiniButton.vue";
 import ChargePointModal from "@/components/Modal/ChargePointModal.vue";
 import DUMMY from "@/consts/dummy";
 
+const tabList = ["마이페이지", "구매내역", "판매내역"];
+const router = useRoute();
 const productDummyList = ref(DUMMY);
 const display = useDisplay();
-const tab = ref("마이페이지");
+const tab = ref(tabList[router.params.index]);
 const showChargePointModal = ref(false);
 const isTablet = ref(display.smAndDown);
 const profile = ref({

--- a/frontend/src/views/MypageView.vue
+++ b/frontend/src/views/MypageView.vue
@@ -10,17 +10,14 @@
           :direction="isTablet ? 'horizontal' : 'vertical'"
           color="subBlue"
         >
-          <v-tab value="마이페이지">
-            <v-icon start> mdi-account </v-icon>
-            마이페이지
-          </v-tab>
-          <v-tab value="구매내역">
-            <v-icon start> mdi-archive </v-icon>
-            구매내역
-          </v-tab>
-          <v-tab value="판매내역">
-            <v-icon start> mdi-currency-krw</v-icon>
-            판매내역
+          <v-tab
+            v-for="t in tabList"
+            :key="t.id"
+            :value="t.title"
+            @click="() => $router.push(`/mypage/${t.id}`)"
+          >
+            <v-icon start> {{ t.icon }} </v-icon>
+            {{ t.title }}
           </v-tab>
         </v-tabs>
         <v-window v-model="tab">
@@ -130,11 +127,27 @@ import MiniButton from "@/components/Button/MiniButton.vue";
 import ChargePointModal from "@/components/Modal/ChargePointModal.vue";
 import DUMMY from "@/consts/dummy";
 
-const tabList = ["마이페이지", "구매내역", "판매내역"];
+const tabList = ref([
+  {
+    id: 0,
+    title: "마이페이지",
+    icon: "mdi-account ",
+  },
+  {
+    id: 1,
+    title: "구매내역",
+    icon: "mdi-archive",
+  },
+  {
+    id: 2,
+    title: "판매내역",
+    icon: "mdi-currency-krw",
+  },
+]);
 const router = useRoute();
 const productDummyList = ref(DUMMY);
 const display = useDisplay();
-const tab = ref(tabList[router.params.index]);
+const tab = ref(tabList.value[router.params.index].title);
 const showChargePointModal = ref(false);
 const isTablet = ref(display.smAndDown);
 const profile = ref({

--- a/frontend/src/views/PurchaseCompleteView.vue
+++ b/frontend/src/views/PurchaseCompleteView.vue
@@ -1,0 +1,69 @@
+<template>
+  <content-layout>
+    <main-title title="구매내역 상세" />
+    <product-banner :product="product" />
+    <product-title title="결제내역" />
+    <div class="infobox">
+      <h4>총 결제금액</h4>
+      <p>{{ product.price.toLocaleString() }}</p>
+    </div>
+    <product-title title="배송정보" />
+    <ul>
+      <li class="infobox">
+        <h4>받는사람</h4>
+        <p>{{ buyeInfo.name }}</p>
+      </li>
+      <li class="infobox">
+        <h4>휴대폰번호</h4>
+        <p>{{ buyeInfo.phoneNumber }}</p>
+      </li>
+      <li class="infobox">
+        <h4>배송주소</h4>
+        <p>{{ buyeInfo.address }}</p>
+      </li>
+    </ul>
+    <v-btn
+      variant="outlined"
+      height="auto"
+      @click="() => $router.push('/mypage/1')"
+      >확인</v-btn
+    >
+  </content-layout>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import ContentLayout from "../layouts/ContentLayout.vue";
+import MainTitle from "@/components/Title/MainTitle.vue";
+import ProductTitle from "@/components/Title/ProductTitle.vue";
+
+const product = ref({
+  title: "아이패드 프로 10.5",
+  price: 700000,
+  thumb: "https://cdn.vuetifyjs.com/images/john.jpg",
+});
+const buyeInfo = ref({
+  name: "김뿅뿅",
+  address: "경기도 고양시 덕양구 신원3로 20",
+  phoneNumber: "01012341234",
+});
+</script>
+
+<style lang="scss" scoped>
+.infobox {
+  display: flex;
+  padding: 10px 0;
+  h4 {
+    flex-basis: 20%;
+    font-weight: 600;
+  }
+}
+.v-btn {
+  margin: 60px 0;
+  width: 100%;
+  padding: 10px 0;
+  font-weight: 600;
+  font-size: 17px;
+  color: rgb(var(--v-theme-subBlue));
+}
+</style>


### PR DESCRIPTION
## 🤷 구현한 기능
구매내역 상세 페이지  UI 구현
## 🖊️ 추가 설명

https://github.com/EASYPEACH/shroop/assets/72537762/e3e4ad26-98ca-4c78-a055-7a7fabd35d46

## 📄 참고 사항
- 구매자가 구매완료 후 마이페이지의 구매내역 탭으로 이동
- 판매자가 운송장 등록후 마이페이지의 판매내역 탭으로 이동

위 두가지를 위해 마이페이지 탭에 라우트 규칙을 추가했습니다
