### PR TITLE
Fix: 구매자정보 조회 API 테스트 코드 오류를 수정한다

### DIFF
--- a/backend/src/test/java/com/easypeach/shroop/modules/transaction/controller/TransactionControllerTest.java
+++ b/backend/src/test/java/com/easypeach/shroop/modules/transaction/controller/TransactionControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.easypeach.shroop.modules.common.ControllerTest;
-import com.easypeach.shroop.modules.member.service.MemberService;
 import com.easypeach.shroop.modules.product.service.ProductService;
 import com.easypeach.shroop.modules.transaction.dto.response.BuyerResponse;
 import com.easypeach.shroop.modules.transaction.service.TransactionService;
@@ -27,9 +26,6 @@ class TransactionControllerTest extends ControllerTest {
 
 	@MockBean
 	ProductService productService;
-
-	@MockBean
-	MemberService memberService;
 
 	@DisplayName("구매자정보 조회")
 	@Test


### PR DESCRIPTION
공통으로 상속 받고 있는 ControllerTest에서 MemberService을 MockBean으로 추가했기 때문에 제거한다.

## 🤷 구현한 기능

## 🖊️ 추가 설명

## 📄 참고 사항
