### PR TITLE
Feat: logout 호출 시 세션에서 사용자 로그인 정보 제거

### DIFF
--- a/backend/src/main/java/com/easypeach/shroop/infra/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easypeach/shroop/infra/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.easypeach.shroop.infra.security;
 
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.tomcat.util.http.Rfc6265CookieProcessor;
 import org.apache.tomcat.util.http.SameSiteCookies;
 import org.springframework.boot.web.embedded.tomcat.TomcatContextCustomizer;
@@ -49,6 +51,16 @@ public class SecurityConfig {
 			.maximumSessions(1)
 			.maxSessionsPreventsLogin(true);
 
+		http.logout(logout ->
+			logout.logoutSuccessUrl("/logout")
+				.permitAll()
+				.deleteCookies("JSESSIONID")
+				.logoutSuccessHandler((request, response, authentication) -> {
+					response.setStatus(HttpServletResponse.SC_OK);
+				})
+				.invalidateHttpSession(true)
+				.clearAuthentication(true));
+
 		http
 			.authorizeRequests()
 			.antMatchers("/api/auth/me", "/api/auth/test",
@@ -56,6 +68,7 @@ public class SecurityConfig {
 			.permitAll()
 			.antMatchers(HttpMethod.GET, "/**")
 			.permitAll()
+			.antMatchers("/api/notifications").hasRole("USER")
 			.anyRequest()
 			.hasRole("USER")
 			.and()


### PR DESCRIPTION
## 🤷 구현한 기능
logout 호출 시 세션에서 사용자 로그인 정보 제거

## 🖊️ 추가 설명
logout 호출 시 세션에서 사용자 로그인 정보 제거

## 📄 참고 사항
logout 호출 시 사용자 정보가 세션에서 제거된 것은 확인했으나
deleteCookies 를 설정해줘도 클라이언트에서 쿠키는 남아있음

https://stackoverflow.com/questions/43773840/spring-security-delete-cookie-for-logout