### PR TITLE
Refactor: 포인트 도입에 따른 거래 로직 수정

### DIFF
--- a/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
@@ -7,6 +7,7 @@ import com.easypeach.shroop.modules.bank.domain.Bank;
 import com.easypeach.shroop.modules.bank.domain.BankRepository;
 import com.easypeach.shroop.modules.bank.exception.MinusMoneyException;
 import com.easypeach.shroop.modules.member.domain.Member;
+import com.easypeach.shroop.modules.member.domain.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class BankService {
 	private final BankRepository bankRepository;
+	private final MemberRepository memberRepository;
 
 	@Transactional
 	public void subtractMoney(final Long point, final Member member) {
@@ -30,8 +32,9 @@ public class BankService {
 	}
 
 	@Transactional
-	public void addPoint(final Long point, final Member member) {
+	public void addMoney(final Long point, final Member member) {
 		Bank bank = bankRepository.getByAccount(member.getAccount());
 		bank.addMoney(point);
 	}
+
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/global/exception/ExceptionControllerAdvice.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/global/exception/ExceptionControllerAdvice.java
@@ -17,6 +17,7 @@ import com.easypeach.shroop.modules.member.exception.MinusPointException;
 import com.easypeach.shroop.modules.member.exception.PasswordNotMatchException;
 import com.easypeach.shroop.modules.product.exception.CategoryNotFoundException;
 import com.easypeach.shroop.modules.product.exception.ProductImgLengthException;
+import com.easypeach.shroop.modules.transaction.exception.LackOfPointException;
 import com.easypeach.shroop.modules.transaction.exception.SellerPurchaseException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -54,7 +55,8 @@ public class ExceptionControllerAdvice {
 		ProductImgLengthException.class,
 		DuplicateValueException.class,
 		PasswordNotMatchException.class,
-		PhoneAuthFailException.class
+		PhoneAuthFailException.class,
+		LackOfPointException.class
 	})
 	public ResponseEntity<ErrorResponse> handleAuthException(final RuntimeException e) {
 		String errorMessage = e.getMessage();

--- a/backend/src/main/java/com/easypeach/shroop/modules/member/controller/PointController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/controller/PointController.java
@@ -33,7 +33,7 @@ public class PointController {
 	@PatchMapping(value = "/exchanging")
 	public ResponseEntity<Long> exchangePoint(@RequestBody final Long point, @LoginMember final Member member) {
 		Long updatedPoint = memberService.subtractPoint(point, member);
-		bankService.addPoint(point, member);
+		bankService.addMoney(point, member);
 
 		return ResponseEntity.status(HttpStatus.OK).body(updatedPoint);
 	}

--- a/backend/src/main/java/com/easypeach/shroop/modules/member/domain/ShroopMember.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/domain/ShroopMember.java
@@ -1,0 +1,14 @@
+package com.easypeach.shroop.modules.member.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum ShroopMember {
+	SHROOP_ID(1L);
+	private Long id;
+
+	ShroopMember(Long id) {
+		this.id = id;
+	}
+
+}

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/TransactionController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/TransactionController.java
@@ -37,16 +37,16 @@ public class TransactionController {
 	// private final PhoneAuthService phoneAuthService;
 
 	@GetMapping("/{productId}")
-	public ResponseEntity<TransactionInfoResponse> getBuyingForm(@PathVariable Long productId,
-		@LoginMember Member member) {
+	public ResponseEntity<TransactionInfoResponse> getBuyingForm(@PathVariable final Long productId,
+		@LoginMember final Member member) {
 		return ResponseEntity.status(HttpStatus.OK).body(transactionService.createTransactionInfoResponse(productId,
 			member));
 	}
 
 	@PostMapping("/{productId}")
 	public ResponseEntity<BasicResponse> buyingProduct(
-		@Validated @RequestBody TransactionCreateRequest transactionCreateRequest,
-		@PathVariable Long productId, final @LoginMember Member member) {
+		@Validated @RequestBody final TransactionCreateRequest transactionCreateRequest,
+		@PathVariable final Long productId, final @LoginMember Member member) {
 
 		transactionService.createTransaction(transactionCreateRequest, productId, member);
 

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/exception/LackOfPointException.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/exception/LackOfPointException.java
@@ -1,0 +1,7 @@
+package com.easypeach.shroop.modules.transaction.exception;
+
+public class LackOfPointException extends RuntimeException {
+	public LackOfPointException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/exception/SellerPurchaseException.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/exception/SellerPurchaseException.java
@@ -2,11 +2,8 @@ package com.easypeach.shroop.modules.transaction.exception;
 
 public class SellerPurchaseException extends RuntimeException {
 
-	private SellerPurchaseException(String message) {
+	public SellerPurchaseException(String message) {
 		super(message);
 	}
 
-	public static SellerPurchaseException SellerBuyingMyProduct() {
-		return new SellerPurchaseException("본인의 상품을 구매할 수 없습니다.");
-	}
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/service/TransactionService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/service/TransactionService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.easypeach.shroop.modules.bank.service.BankService;
 import com.easypeach.shroop.modules.member.domain.Member;
+import com.easypeach.shroop.modules.member.domain.ShroopMember;
 import com.easypeach.shroop.modules.member.service.MemberService;
 import com.easypeach.shroop.modules.notification.service.NotificationService;
 import com.easypeach.shroop.modules.product.domain.Product;
@@ -72,10 +73,10 @@ public class TransactionService {
 		}
 
 		//슈룹이 포인트 보관
-		addPoint(productId, 1L);
+		addPoint(productId, ShroopMember.SHROOP_ID.getId());
 
 		//슈룹이 수수료 가져감
-		bankService.addMoney(fee, memberService.findById(1L));
+		bankService.addMoney(fee, memberService.findById(ShroopMember.SHROOP_ID.getId()));
 
 		// phoneAuthService.sendSms(product.getSeller().getPhoneNumber(),
 		// 	String.format("%s 판매자님 %s 상품이 결제되었습니다.", product.getSeller().getNickname(), product.getTitle()));

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/service/TransactionService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/service/TransactionService.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.easypeach.shroop.modules.bank.service.BankService;
 import com.easypeach.shroop.modules.member.domain.Member;
 import com.easypeach.shroop.modules.member.service.MemberService;
 import com.easypeach.shroop.modules.notification.service.NotificationService;
@@ -26,6 +27,7 @@ import com.easypeach.shroop.modules.transaction.dto.response.TransactionCreatedR
 import com.easypeach.shroop.modules.transaction.dto.response.TransactionInfoResponse;
 import com.easypeach.shroop.modules.transaction.exception.IsNotBuyerException;
 import com.easypeach.shroop.modules.transaction.exception.IsNotSellerException;
+import com.easypeach.shroop.modules.transaction.exception.LackOfPointException;
 import com.easypeach.shroop.modules.transaction.exception.SellerPurchaseException;
 
 import lombok.RequiredArgsConstructor;
@@ -46,6 +48,41 @@ public class TransactionService {
 
 	private final NotificationService notificationService;
 
+	private final BankService bankService;
+
+	@Transactional
+	public void createTransaction(final TransactionCreateRequest transactionCreateRequest, final Long productId,
+		final Member member) {
+		Product product = productService.findByProductId(productId);
+
+		Long price = product.getPrice();
+		Long fee = Math.round(price * 0.035);
+		Long totalprice = price + fee;
+
+		checkSeller(member, product.getSeller());
+
+		// 거래 저장
+		saveTransaction(productId, member.getId(), transactionCreateRequest);
+
+		// 구매자에게 포인트 차감
+		if (member.getPoint() >= totalprice) {
+			subtractPoint(totalprice, member.getId());
+		} else {
+			throw new LackOfPointException("포인트가 부족합니다.");
+		}
+
+		//슈룹이 포인트 보관
+		addPoint(productId, 1L);
+
+		//슈룹이 수수료 가져감
+		bankService.addMoney(fee, memberService.findById(1L));
+
+		// phoneAuthService.sendSms(product.getSeller().getPhoneNumber(),
+		// 	String.format("%s 판매자님 %s 상품이 결제되었습니다.", product.getSeller().getNickname(), product.getTitle()));
+
+		log.info("{} 판매자님 {} 상품이 결제되었습니다.", product.getSeller().getNickname(), product.getTitle());
+	}
+
 	@Transactional
 	public void saveTransaction(final Long productId, final Long buyerId,
 		final TransactionCreateRequest transactionCreateRequest) {
@@ -61,12 +98,11 @@ public class TransactionService {
 	}
 
 	@Transactional
-	public void subtractPoint(final Long productId, final Long buyerId) {
+	public void subtractPoint(final Long totalprice, final Long buyerId) {
 
-		Product product = productService.findByProductId(productId);
 		Member buyer = memberService.findById(buyerId);
 
-		long updatedPoint = Math.max(buyer.getPoint() - product.getPrice(), 0L);
+		long updatedPoint = buyer.getPoint() - totalprice;
 		buyer.updatePoint(updatedPoint);
 	}
 
@@ -82,11 +118,11 @@ public class TransactionService {
 
 	public void checkSeller(final Member member, final Member seller) {
 		if (seller.getId() == member.getId()) {
-			throw SellerPurchaseException.SellerBuyingMyProduct();
+			throw new SellerPurchaseException("본인의 상품을 구매할 수 없습니다.");
 		}
 	}
 
-	public TransactionInfoResponse createTransactionInfoResponse(Long productId, Member member) {
+	public TransactionInfoResponse createTransactionInfoResponse(final Long productId, final Member member) {
 		Product product = productService.findByProductId(productId);
 		ProductImg productImg = productService.getProductImg(product);
 		String productImgUrl = productImg.getProductImgUrl();
@@ -96,21 +132,7 @@ public class TransactionService {
 			product.getPrice(), findedMember.getPoint());
 	}
 
-	@Transactional
-	public void createTransaction(TransactionCreateRequest transactionCreateRequest, Long productId, Member member) {
-		Product product = productService.findByProductId(productId);
-		checkSeller(member, product.getSeller());
-
-		saveTransaction(productId, member.getId(), transactionCreateRequest);
-		subtractPoint(productId, member.getId());
-
-		// phoneAuthService.sendSms(product.getSeller().getPhoneNumber(),
-		// 	String.format("%s 판매자님 %s 상품이 결제되었습니다.", product.getSeller().getNickname(), product.getTitle()));
-
-		log.info("{} 판매자님 {} 상품이 결제되었습니다.", product.getSeller().getNickname(), product.getTitle());
-	}
-
-	public TransactionCreatedResponse createTransactionCreatedResponse(Long productId) {
+	public TransactionCreatedResponse createTransactionCreatedResponse(final Long productId) {
 		Product product = productService.findByProductId(productId);
 		Transaction transaction = product.getTransaction();
 		ProductImg productImg = productService.getProductImg(product);
@@ -134,14 +156,14 @@ public class TransactionService {
 		return transactionRepository.getByProductId(productId);
 	}
 
-	public List<HistoryResponse> findAllBuyingHistory(Member member) {
+	public List<HistoryResponse> findAllBuyingHistory(final Member member) {
 		List<Transaction> transactionList = transactionRepository.findAllByBuyer(member);
 		return transactionList.stream()
 			.map(HistoryResponse::new)
 			.collect(Collectors.toList());
 	}
 
-	public PageResponse findAllSellingHistory(Member member, Pageable pageable) {
+	public PageResponse findAllSellingHistory(final Member member, final Pageable pageable) {
 
 		Page<Product> page = productRepository.findBySeller(member, pageable);
 		int pageCount = page.getTotalPages();

--- a/backend/src/main/resources/import.sql
+++ b/backend/src/main/resources/import.sql
@@ -5,6 +5,7 @@ insert into bank (id, account, name) values (2, '002-106607-01-016', '이종민'
 insert into bank (id, account, name) values (3, '01085518532', '공태식');
 insert into bank (id, account, name) values (4, '01030831889', '박진영');
 insert into bank (id, account, name) values (5, '01054834790', '박지윤');
+insert into bank (id, account, name) values (6, '01054834792', 'test6');
 
 ## admin 비밀번호는 전부 's93949697!'
 
@@ -14,7 +15,7 @@ insert into member (id, check_agree, create_date, login_date, login_id, nickname
 insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date, account) values (4, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'parkjinyoung',  '지녕쿤', '$2y$10$F26pbdd5v2A3NAplkgh9YujhqcbE7Jto2emEZg516FBwapp0XGKJC', '01030831889', 1000000, 'ROLE_ADMIN', '2023-04-07 17:45:22', '01030831889');
 insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date, account) values (5, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'parkjiyun',  '갓쥰', '$2y$10$F26pbdd5v2A3NAplkgh9YujhqcbE7Jto2emEZg516FBwapp0XGKJC', '01054834790', 1000000, 'ROLE_ADMIN', '2023-04-07 17:45:22', '01054834790');
 
-insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date) values (6, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'test111111',  'test111111', '$2y$10$tRo6AL3AMRBOXPTfqAFNBO06/2zGMTr5Cvkc5CoS0sjgnovVLCyRu', '01012345671', 1000, 'ROLE_USER', '2023-04-07 17:45:22');
+insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date, account) values (6, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'test111111',  'test111111', '$2y$10$tRo6AL3AMRBOXPTfqAFNBO06/2zGMTr5Cvkc5CoS0sjgnovVLCyRu', '01012345671', 100000, 'ROLE_USER', '2023-04-07 17:45:22',01054834792);
 insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date) values (7, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'test222222',  'test222222', '$2y$10$nffYvzFk6vBB5J.8HFLjkuoaLmXvrtZ97Ivk4eAjWLXIUjvHc5YAe', '01012345672', 1000, 'ROLE_USER', '2023-04-07 17:45:22');
 insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date) values (8, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'test333333',  'test333333', '$2y$10$xsWyO3tEhyaU79pQcHw.3OPjudF4PYrhtoqD/lKd41RscMTfffz62', '01012345673', 1000, 'ROLE_USER', '2023-04-07 17:45:22');
 insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date) values (9, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'test444444',  'test444444', '$2y$10$JWTEL/Hlz93Q88V8WN7.9Os32EgsrC1vtHsKn/FUJ7CIwRC3ll6eC', '01012345674', 1000, 'ROLE_USER', '2023-04-07 17:45:22');

--- a/backend/src/test/java/com/easypeach/shroop/modules/member/controller/PointControllerTest.java
+++ b/backend/src/test/java/com/easypeach/shroop/modules/member/controller/PointControllerTest.java
@@ -39,7 +39,7 @@ class PointControllerTest extends ControllerTest {
 		Long updatedPoint = 60000L;
 
 		given(memberService.subtractPoint(eq(10000L), any())).willReturn(updatedPoint);
-		doNothing().when(bankService).addPoint(eq(10000L), any());
+		doNothing().when(bankService).addMoney(eq(10000L), any());
 
 		mockMvc.perform(MockMvcRequestBuilders.patch("/api/point/exchanging")
 				.contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 🤷 구현한 기능
결제 시 고객에게 차감한 포인트를 보관하는 기능과 수수료를 슈룹 계좌에 넣는 로직 추가

## 🖊️ 추가 설명
결제 시 고객의 포인트에서 상품 가격과 수수료를 더한 금액을 차감했습니다. 이에 따라상품의 가격만큼 슈룹 보관소에 포인트를 보관했고, 수수료는 슈룹의 계좌로 넣어줬습니다.

## 📄 참고 사항
