### PR TITLE
Refactor: 계좌 연동하기 API 리팩토링, 계좌 생성 API 구현

### DIFF
--- a/backend/src/main/java/com/easypeach/shroop/infra/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easypeach/shroop/infra/security/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
 		http
 			.authorizeRequests()
 			.antMatchers("/api/auth/me", "/api/auth/test",
-				"/api/auth/sign-up", "/api/auth/phone/**", "/api/auth/sign-in", "/check/**")
+				"/api/auth/sign-up", "/api/auth/phone/**", "/api/auth/sign-in", "/check/**", "/api/bank/creating")
 			.permitAll()
 			.antMatchers(HttpMethod.GET, "/**")
 			.permitAll()

--- a/backend/src/main/java/com/easypeach/shroop/modules/bank/controller/BankController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/bank/controller/BankController.java
@@ -30,4 +30,11 @@ public class BankController {
 		bankService.linkingAccount(linkBankRequest, member);
 		return ResponseEntity.ok(new BasicResponse("계좌가 연동되었습니다."));
 	}
+
+	@PostMapping("/creating")
+	public ResponseEntity<BasicResponse> creatingAccount(
+		@Validated @RequestBody final LinkBankRequest linkBankRequest) {
+		bankService.creatingAccount(linkBankRequest);
+		return ResponseEntity.ok(new BasicResponse("계좌가 생성되었습니다."));
+	}
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/bank/domain/Bank.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/bank/domain/Bank.java
@@ -28,6 +28,9 @@ public class Bank {
 	@Column(length = 50, nullable = false, unique = true)
 	private String account;
 
+	@Column(length = 500, nullable = false)
+	private String password;
+
 	@ColumnDefault(value = "1000000")
 	@Column(nullable = false)
 	private Long money;
@@ -40,10 +43,11 @@ public class Bank {
 		this.money -= point;
 	}
 
-	public static Bank createBank(String name, String account) {
+	public static Bank createBank(String name, String account, String encodedPassword) {
 		Bank bank = new Bank();
 		bank.name = name;
 		bank.account = account;
+		bank.password = encodedPassword;
 		return bank;
 	}
 

--- a/backend/src/main/java/com/easypeach/shroop/modules/bank/dto/LinkBankRequest.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/bank/dto/LinkBankRequest.java
@@ -19,10 +19,15 @@ public class LinkBankRequest {
 	@Pattern(regexp = "^(\\d{1,})(-(\\d{1,})){1,}", message = "계좌번호 형식이 잘못되었습니다.")
 	private String account;
 
+	@NotBlank
+	@Size(min = 4, max = 4, message = "비밀번호 4글자를 입력해주세요")
+	private String password;
+
 	public static LinkBankRequest dtoForTest() {
 		LinkBankRequest dto = new LinkBankRequest();
 		dto.name = "아무개";
 		dto.account = "010-12345-12345";
+		dto.password = "1234";
 		return dto;
 	}
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/bank/exception/AccountMismatchException.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/bank/exception/AccountMismatchException.java
@@ -1,0 +1,8 @@
+package com.easypeach.shroop.modules.bank.exception;
+
+public class AccountMismatchException extends RuntimeException {
+
+	public AccountMismatchException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
@@ -1,11 +1,13 @@
 package com.easypeach.shroop.modules.bank.service;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.easypeach.shroop.modules.bank.domain.Bank;
 import com.easypeach.shroop.modules.bank.domain.BankRepository;
 import com.easypeach.shroop.modules.bank.dto.LinkBankRequest;
+import com.easypeach.shroop.modules.bank.exception.AccountMismatchException;
 import com.easypeach.shroop.modules.bank.exception.MinusMoneyException;
 import com.easypeach.shroop.modules.member.domain.Member;
 import com.easypeach.shroop.modules.member.domain.MemberRepository;
@@ -20,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class BankService {
 	private final BankRepository bankRepository;
 	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
 
 	@Transactional
 	public void subtractMoney(final Long point, final Member member) {
@@ -38,13 +41,25 @@ public class BankService {
 		bank.addMoney(point);
 	}
 
-
 	@Transactional
 	public void linkingAccount(final LinkBankRequest linkBankRequest, final Member member) {
-		// member에 계좌를 넣어주고, bank에 새로운 계좌 등록
+		String EnteredPassword = linkBankRequest.getPassword();
+		String encodedEnteredPassword = passwordEncoder.encode(EnteredPassword);
+
 		Member foundMember = memberRepository.getById(member.getId());
-		foundMember.updateAccount(linkBankRequest.getAccount());
-		Bank bank = Bank.createBank(linkBankRequest.getName(), linkBankRequest.getAccount());
+		String encodedBankPassword = foundMember.getPassword();
+
+		boolean isMatchedPassword = passwordEncoder.matches(encodedEnteredPassword, encodedBankPassword);
+		if (isMatchedPassword) {
+			foundMember.updateAccount(linkBankRequest.getAccount());
+		} else {
+			throw new AccountMismatchException("계좌번호가 일치하지 않습니다.");
+		}
+	}
+
+	public void creatingAccount(LinkBankRequest linkBankRequest) {
+		String encodedPassword = passwordEncoder.encode(linkBankRequest.getPassword());
+		Bank bank = Bank.createBank(linkBankRequest.getName(), linkBankRequest.getAccount(), encodedPassword);
 		bankRepository.save(bank);
 	}
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
@@ -43,27 +43,42 @@ public class BankService {
 
 	@Transactional
 	public void linkingAccount(final LinkBankRequest linkBankRequest, final Member member) {
-		String EnteredAccount = linkBankRequest.getAccount();
-		String EnteredPassword = linkBankRequest.getPassword();
-		String encodedEnteredPassword = passwordEncoder.encode(EnteredPassword);
 
 		Member foundMember = memberRepository.getById(member.getId());
-		String encodedBankPassword = foundMember.getPassword();
-		String BankAccount = foundMember.getAccount();
 
-		boolean isMatchedPassword = passwordEncoder.matches(encodedEnteredPassword, encodedBankPassword);
-		boolean isMatchedAccount = EnteredAccount.matches(BankAccount);
-
-		if (isMatchedPassword && isMatchedAccount) {
+		boolean isAuthenticate = authenticateAccount(linkBankRequest, member);
+		if (isAuthenticate) {
 			foundMember.updateAccount(linkBankRequest.getAccount());
 		} else {
 			throw new AccountMismatchException("계좌번호가 일치하지 않습니다.");
 		}
 	}
 
+	@Transactional
 	public void creatingAccount(LinkBankRequest linkBankRequest) {
 		String encodedPassword = passwordEncoder.encode(linkBankRequest.getPassword());
 		Bank bank = Bank.createBank(linkBankRequest.getName(), linkBankRequest.getAccount(), encodedPassword);
 		bankRepository.save(bank);
+	}
+
+	public boolean authenticateAccount(LinkBankRequest linkBankRequest, Member member) {
+		String enteredName = linkBankRequest.getName();
+		String enteredAccount = linkBankRequest.getAccount();
+		String enteredPassword = linkBankRequest.getPassword();
+
+		String encodedEnteredPassword = passwordEncoder.encode(enteredPassword);
+		
+		Bank foundBank = bankRepository.getByAccount(enteredAccount);
+
+		String bankName = foundBank.getName();
+		String encodedBankPassword = foundBank.getPassword();
+
+		boolean isMatchedPassword = passwordEncoder.matches(encodedEnteredPassword, encodedBankPassword);
+		boolean isMatchedName = bankName.matches(enteredName);
+		if (isMatchedPassword && isMatchedName) {
+			return true;
+		} else {
+			return false;
+		}
 	}
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
@@ -67,14 +67,14 @@ public class BankService {
 		String enteredPassword = linkBankRequest.getPassword();
 
 		String encodedEnteredPassword = passwordEncoder.encode(enteredPassword);
-		
+
 		Bank foundBank = bankRepository.getByAccount(enteredAccount);
 
 		String bankName = foundBank.getName();
 		String encodedBankPassword = foundBank.getPassword();
 
 		boolean isMatchedPassword = passwordEncoder.matches(encodedEnteredPassword, encodedBankPassword);
-		boolean isMatchedName = bankName.matches(enteredName);
+		boolean isMatchedName = bankName.equals(enteredName);
 		if (isMatchedPassword && isMatchedName) {
 			return true;
 		} else {

--- a/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
@@ -43,14 +43,18 @@ public class BankService {
 
 	@Transactional
 	public void linkingAccount(final LinkBankRequest linkBankRequest, final Member member) {
+		String EnteredAccount = linkBankRequest.getAccount();
 		String EnteredPassword = linkBankRequest.getPassword();
 		String encodedEnteredPassword = passwordEncoder.encode(EnteredPassword);
 
 		Member foundMember = memberRepository.getById(member.getId());
 		String encodedBankPassword = foundMember.getPassword();
+		String BankAccount = foundMember.getAccount();
 
 		boolean isMatchedPassword = passwordEncoder.matches(encodedEnteredPassword, encodedBankPassword);
-		if (isMatchedPassword) {
+		boolean isMatchedAccount = EnteredAccount.matches(BankAccount);
+
+		if (isMatchedPassword && isMatchedAccount) {
 			foundMember.updateAccount(linkBankRequest.getAccount());
 		} else {
 			throw new AccountMismatchException("계좌번호가 일치하지 않습니다.");

--- a/backend/src/main/resources/import.sql
+++ b/backend/src/main/resources/import.sql
@@ -1,11 +1,12 @@
 
-
-insert into bank (id, account, name, money) values (1, '002-93949697-003', '슈룹', 0);
-insert into bank (id, account, name) values (2, '002-106607-01-016', '이종민');
-insert into bank (id, account, name) values (3, '01085518532', '공태식');
-insert into bank (id, account, name) values (4, '01030831889', '박진영');
-insert into bank (id, account, name) values (5, '01054834790', '박지윤');
-insert into bank (id, account, name) values (6, '01054834792', 'test6');
+## 계좌 비밀번호는 1234
+insert into bank (id, account, name, money, password) values (1, '002-93949697-003', '슈룹', 0, "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
+insert into bank (id, account, name, password) values (2, '002-106607-01-016', '이종민', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
+insert into bank (id, account, name, password) values (3, '01085518532', '공태식', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
+insert into bank (id, account, name, password) values (4, '01030831889', '박진영', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
+insert into bank (id, account, name, password) values (5, '01054834790', '박지윤',"$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
+insert into bank (id, account, name, password) values (6, '01054834792', 'test1', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
+insert into bank (id, account, name, password) values (7, '010-9394-9697', 'test2', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
 
 ## admin 비밀번호는 전부 's93949697!'
 


### PR DESCRIPTION
## 🤷 구현한 기능
- 계좌 연동하기 API 리팩토링
- 계좌 생성 API 구현
## 🖊️ 추가 설명
- 계좌 연동 창에서 4자리의 비밀번호가 입력되면, 암호화하여 은행의 암호화된 번호와 일치하는지 확인하고 ,이름도 일치하는지 확인하고 일치하면 멤버의 계좌와 연동시켜주는 로직입니다.
- 계좌를 생성하는 창은 필요하지 않고, sql 파일에 더미 데이터를 넣기 번거로울거 같아서 포스트맨 용으로 계좌 생성 API를 만들어 뒀습니다.
## 📄 참고 사항
@jiny798 가 알려준 PasswordEncoder