### PR TITLE
Feat: AOP 로그 추적기 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -68,6 +68,8 @@ dependencies {
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 
+    // aop 설정
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/easypeach/shroop/infra/aop/log/user/UserLog.java
+++ b/backend/src/main/java/com/easypeach/shroop/infra/aop/log/user/UserLog.java
@@ -1,0 +1,52 @@
+package com.easypeach.shroop.infra.aop.log.user;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import com.easypeach.shroop.modules.member.domain.Member;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_log")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserLog {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long memberId;
+
+	@Column
+	private String log;
+
+	private String paramName;
+
+	@Column(length = 10000)
+	private String paramValue;
+
+	private LocalDateTime createdTime;
+
+	public static UserLog createUserLog(Long memberId,String log){
+		UserLog userLog = new UserLog();
+		userLog.memberId = memberId;
+		userLog.log= log;
+		userLog.createdTime = LocalDateTime.now();
+		return userLog;
+	}
+
+	public void setParamName(String name){
+		this.paramName = name;
+	}
+	public void setParamValue(String value){
+		this.paramValue = value;
+	}
+}

--- a/backend/src/main/java/com/easypeach/shroop/infra/aop/log/user/UserLogDto.java
+++ b/backend/src/main/java/com/easypeach/shroop/infra/aop/log/user/UserLogDto.java
@@ -1,0 +1,12 @@
+package com.easypeach.shroop.infra.aop.log.user;
+
+import javax.persistence.Column;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+public class UserLogDto {
+	private Long memberId;
+	private String log;
+}

--- a/backend/src/main/java/com/easypeach/shroop/infra/aop/log/user/UserLogRepository.java
+++ b/backend/src/main/java/com/easypeach/shroop/infra/aop/log/user/UserLogRepository.java
@@ -1,0 +1,8 @@
+package com.easypeach.shroop.infra.aop.log.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserLogRepository extends JpaRepository<UserLog,Long> {
+}

--- a/backend/src/main/java/com/easypeach/shroop/infra/aop/log/user/UserTrace.java
+++ b/backend/src/main/java/com/easypeach/shroop/infra/aop/log/user/UserTrace.java
@@ -1,0 +1,12 @@
+package com.easypeach.shroop.infra.aop.log.user;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserTrace {
+	String value() default "content";
+}

--- a/backend/src/main/java/com/easypeach/shroop/infra/aop/log/user/UserTraceAspect.java
+++ b/backend/src/main/java/com/easypeach/shroop/infra/aop/log/user/UserTraceAspect.java
@@ -1,0 +1,59 @@
+package com.easypeach.shroop.infra.aop.log.user;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import com.easypeach.shroop.modules.member.domain.Member;
+import com.easypeach.shroop.modules.member.dto.request.ProfileEditRequest;
+import com.easypeach.shroop.modules.product.dto.request.ProductRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+@Aspect
+public class UserTraceAspect {
+
+	private final UserLogRepository logRepository;
+
+	private final Class[] checkArgsType = {ProductRequest.class,
+		Long.class,
+		ProfileEditRequest.class,
+		ArrayList.class};
+
+	@Around("@annotation(userTrace)")
+	public Object doTrace(ProceedingJoinPoint joinPoint,UserTrace userTrace) throws Throwable {
+		Object[] args = joinPoint.getArgs();
+		UserLogDto logDto = new UserLogDto();
+
+		Arrays.stream(args).forEach(o -> {
+			if(o instanceof Member){ // 로그인된 사용자만 로그를 기록한다
+				Member member = (Member)o;
+				logDto.setMemberId(member.getId());
+				logDto.setLog(userTrace.value());
+			}
+		});
+
+		for(Object obj : args) {
+			if(obj !=null) {
+				for(Class c : checkArgsType){
+					if(c.equals(obj.getClass())){
+						UserLog userLog = UserLog.createUserLog(logDto.getMemberId(), logDto.getLog());
+						userLog.setParamName(obj.getClass().getName()); //파라미터 이름 저장
+						userLog.setParamValue(obj.toString()); // 파라미터 값 저장
+						logRepository.save(userLog);
+					}
+				}
+			}
+		}
+		return joinPoint.proceed();
+
+	}
+
+}

--- a/backend/src/main/java/com/easypeach/shroop/infra/security/handler/SecurityAuthenticationSuccessHandler.java
+++ b/backend/src/main/java/com/easypeach/shroop/infra/security/handler/SecurityAuthenticationSuccessHandler.java
@@ -12,6 +12,8 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.stereotype.Component;
 
+import com.easypeach.shroop.infra.aop.log.user.UserLog;
+import com.easypeach.shroop.infra.aop.log.user.UserLogRepository;
 import com.easypeach.shroop.modules.auth.domain.SecurityMember;
 import com.easypeach.shroop.modules.auth.dto.response.LoginSuccessResponse;
 import com.easypeach.shroop.modules.global.exception.dto.ErrorResponse;
@@ -27,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SecurityAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
 	private final ObjectMapper objectMapper;
+	private final UserLogRepository userLogRepository;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -40,6 +43,9 @@ public class SecurityAuthenticationSuccessHandler implements AuthenticationSucce
 		SecurityMember securityMember = (SecurityMember) authentication.getPrincipal();
 		Member member = securityMember.getMember();
 		LoginSuccessResponse loginDto = new LoginSuccessResponse(member.getLoginId(),member.getNickname());
+
+		UserLog userLog = UserLog.createUserLog(member.getId(),"로그인 성공");
+		userLogRepository.save(userLog);
 
 		String loginDtoAsString = objectMapper.writeValueAsString(loginDto);
 		response.getWriter().write(loginDtoAsString);

--- a/backend/src/main/java/com/easypeach/shroop/modules/global/exception/ExceptionControllerAdvice.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/global/exception/ExceptionControllerAdvice.java
@@ -67,7 +67,7 @@ public class ExceptionControllerAdvice {
 	@ExceptionHandler
 	public ResponseEntity<ErrorResponse> handleException(final Exception e) {
 		String errorMessage = e.getMessage();
-		log.error(e.getMessage());
+		log.error("ERROR {}",e);
 		ErrorResponse errorResponse = new ErrorResponse("내부 서버에 문제가 발생하여 확인 중 입니다");
 		return ResponseEntity.internalServerError().body(errorResponse);
 	}

--- a/backend/src/main/java/com/easypeach/shroop/modules/likes/controller/LikeController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/likes/controller/LikeController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.easypeach.shroop.infra.aop.log.user.UserTrace;
 import com.easypeach.shroop.modules.auth.support.LoginMember;
 import com.easypeach.shroop.modules.likes.service.LikeService;
 import com.easypeach.shroop.modules.member.domain.Member;
@@ -23,6 +24,7 @@ public class LikeController {
 
 	private final LikeService likeService;
 
+	@UserTrace(value = "좋아요를 클릭하였습니다")
 	@PostMapping("/{productId}")
 	public ResponseEntity<Long> saveLikes(@LoginMember Member member, @PathVariable Long productId) {
 		return ResponseEntity.status(HttpStatus.OK).body(likeService.saveLikes(member, productId));

--- a/backend/src/main/java/com/easypeach/shroop/modules/member/controller/MemberController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.easypeach.shroop.infra.aop.log.user.UserTrace;
 import com.easypeach.shroop.modules.auth.support.LoginMember;
 import com.easypeach.shroop.modules.global.response.BasicResponse;
 import com.easypeach.shroop.modules.member.domain.Member;
@@ -30,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberController {
 	private final MemberService memberService;
 
+	@UserTrace(value = "마이페이지 이동")
 	@GetMapping("/me")
 	public ResponseEntity<MyPageInfoResponse> findMyPage(@LoginMember final Member member, Pageable pageable){
 		MyPageInfoResponse myInfo = memberService.getMyInfo(member.getId(),pageable);

--- a/backend/src/main/java/com/easypeach/shroop/modules/member/dto/request/ProfileEditRequest.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/dto/request/ProfileEditRequest.java
@@ -6,7 +6,9 @@ import javax.validation.constraints.Size;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
+@ToString
 @Getter
 @NoArgsConstructor
 public class ProfileEditRequest {

--- a/backend/src/main/java/com/easypeach/shroop/modules/product/controller/ProductController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/product/controller/ProductController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.easypeach.shroop.infra.aop.log.user.UserTrace;
 import com.easypeach.shroop.modules.auth.support.LoginMember;
 import com.easypeach.shroop.modules.global.response.BasicResponse;
 import com.easypeach.shroop.modules.member.domain.Member;
@@ -51,6 +52,7 @@ public class ProductController {
 		return ResponseEntity.status(HttpStatus.OK).body(productService.getProductInfo(member, productId));
 	}
 
+	@UserTrace(value = "상품을 등록하였습니다")
 	@PostMapping
 	public ResponseEntity<ProductCreatedResponse> saveProduct(@LoginMember Member member,
 		@RequestPart(value = "productImgList") List<MultipartFile> productImgList,
@@ -59,9 +61,11 @@ public class ProductController {
 		productImgService.checkImgLength(productImgList);
 		Product product = productService.saveProduct(member.getId(), productRequest);
 		productImgService.saveProductImg(productImgList, defectImgList, product, productRequest.getIsDefect());
+		log.info("상품 등록 로그 {}",product.getId());
 		return ResponseEntity.status(HttpStatus.OK).body(new ProductCreatedResponse(product.getId()));
 	}
 
+	@UserTrace(value = "상품을 수정하였습니다")
 	@PatchMapping
 	public ResponseEntity<ProductCreatedResponse> updateProduct(@LoginMember Member member,
 		@RequestPart(value = "productId") Long productId,

--- a/backend/src/main/java/com/easypeach/shroop/modules/product/dto/request/ProductRequest.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/product/dto/request/ProductRequest.java
@@ -10,7 +10,9 @@ import com.easypeach.shroop.modules.product.domain.ProductGrade;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
+@ToString
 @Getter
 @NoArgsConstructor
 public class ProductRequest {

--- a/backend/src/main/java/com/easypeach/shroop/modules/report/controller/ReportController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/report/controller/ReportController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.easypeach.shroop.infra.aop.log.user.UserTrace;
 import com.easypeach.shroop.modules.auth.support.LoginMember;
 import com.easypeach.shroop.modules.global.response.BasicResponse;
 import com.easypeach.shroop.modules.member.domain.Member;
@@ -32,6 +33,7 @@ public class ReportController {
 
 	private final ReportImgService reportImgService;
 
+	@UserTrace(value = "해당 사용자가 다른 사용자를 신고하였습니다")
 	@PostMapping
 	public ResponseEntity<BasicResponse> saveReport(
 		@LoginMember Member member,

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/DeliveryController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/DeliveryController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.easypeach.shroop.infra.aop.log.user.UserTrace;
 import com.easypeach.shroop.modules.auth.dto.response.DuplicateValidResponse;
 import com.easypeach.shroop.modules.global.response.BasicResponse;
 import com.easypeach.shroop.modules.transaction.dto.request.DeliveryRequest;
@@ -26,6 +27,7 @@ public class DeliveryController {
 
 	private final DeliveryService deliveryService;
 
+	@UserTrace(value = "운송장 번호를 등록 하였습니다")
 	@PostMapping("/{productId}")
 	public ResponseEntity<BasicResponse> saveDelivery(
 		final @PathVariable Long productId,

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/TransactionController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/TransactionController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.easypeach.shroop.infra.aop.log.user.UserTrace;
 import com.easypeach.shroop.modules.auth.support.LoginMember;
 import com.easypeach.shroop.modules.global.response.BasicResponse;
 import com.easypeach.shroop.modules.member.domain.Member;
@@ -43,6 +44,7 @@ public class TransactionController {
 			member));
 	}
 
+	@UserTrace(value = "거래를 요청하였습니다")
 	@PostMapping("/{productId}")
 	public ResponseEntity<BasicResponse> buyingProduct(
 		@Validated @RequestBody final TransactionCreateRequest transactionCreateRequest,


### PR DESCRIPTION
## 🤷 구현한 기능
AOP 로그 추적기 구현
- 로그인, 상품 등록, 좋아요, 프로필 수정 시 로그가 DB에 저장되도록 구현
- 테이블명 : user_log

## 🖊️ 추가 설명
![image](https://github.com/EASYPEACH/shroop/assets/122027452/55229c26-4057-4385-93ab-6eed463311b8)
log 는 사용자의 액션이 기록됩니다

param_name 에는 사용자가 요청 시 넘겼던 파라미터 이름이 기록됩니다 (ex. DTO 클래스 이름)
param_value 에는 파라미터 value 가 기록됩니다. ( ex 프로필 수정 시 넘겼던 닉네임 값, 비밀번호 등이 기록 )

## 📄 참고 사항
