### PR TITLE
Feat: 포인트 반영 API 프론트 연동 및 API 리팩토링

### DIFF
--- a/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
@@ -26,7 +26,6 @@ public class BankService {
 
 	@Transactional
 	public void subtractMoney(final Long point, final Member member) {
-		// System.out.println(member.getAccount());
 		Member foundMember = memberRepository.getById(member.getId());
 		Bank bank = bankRepository.getByAccount(foundMember.getAccount());
 		if (bank.getMoney() >= point) {

--- a/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/bank/service/BankService.java
@@ -26,8 +26,9 @@ public class BankService {
 
 	@Transactional
 	public void subtractMoney(final Long point, final Member member) {
-
-		Bank bank = bankRepository.getByAccount(member.getAccount());
+		// System.out.println(member.getAccount());
+		Member foundMember = memberRepository.getById(member.getId());
+		Bank bank = bankRepository.getByAccount(foundMember.getAccount());
 		if (bank.getMoney() >= point) {
 			bank.subtractMoney(point);
 		} else {
@@ -37,7 +38,8 @@ public class BankService {
 
 	@Transactional
 	public void addMoney(final Long point, final Member member) {
-		Bank bank = bankRepository.getByAccount(member.getAccount());
+		Member foundMember = memberRepository.getById(member.getId());
+		Bank bank = bankRepository.getByAccount(foundMember.getAccount());
 		bank.addMoney(point);
 	}
 

--- a/backend/src/main/java/com/easypeach/shroop/modules/member/dto/reponse/MyPageInfoResponse.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/dto/reponse/MyPageInfoResponse.java
@@ -13,5 +13,6 @@ public class MyPageInfoResponse {
 	private String userImg;
 	private String nickname;
 	private Long point;
+	private String account;
 	private Page<LikeProductInfo> page;
 }

--- a/backend/src/main/java/com/easypeach/shroop/modules/member/service/MemberService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/service/MemberService.java
@@ -51,6 +51,7 @@ public class MemberService {
 			findMember.getProfileImg(),
 			findMember.getNickname(),
 			findMember.getPoint(),
+			findMember.getAccount(),
 			likedProductList
 		);
 
@@ -173,7 +174,7 @@ public class MemberService {
 	@Transactional
 	public Long subtractPoint(final Long point, final Member member) {
 		Member foundMember = memberRepository.getById(member.getId());
-		if (member.getPoint() >= point) {
+		if (foundMember.getPoint() >= point) {
 			foundMember.subtractPoint(point);
 		} else {
 			throw new MinusPointException("보유한 포인트보다 환전하려는 포인트가 더 큽니다. 다시 입력해주세요");

--- a/backend/src/main/resources/import.sql
+++ b/backend/src/main/resources/import.sql
@@ -2,11 +2,12 @@
 ## 계좌 비밀번호는 1234
 insert into bank (id, account, name, money, password) values (1, '002-93949697-003', '슈룹', 0, "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
 insert into bank (id, account, name, password) values (2, '002-106607-01-016', '이종민', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
-insert into bank (id, account, name, password) values (3, '01085518532', '공태식', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
-insert into bank (id, account, name, password) values (4, '01030831889', '박진영', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
-insert into bank (id, account, name, password) values (5, '01054834790', '박지윤',"$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
-insert into bank (id, account, name, password) values (6, '01054834792', 'test1', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
+insert into bank (id, account, name, password) values (3, '010-8551-8532', '공태식', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
+insert into bank (id, account, name, password) values (4, '010-3083-1889', '박진영', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
+insert into bank (id, account, name, password) values (5, '010-5483-4790', '박지윤',"$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
+insert into bank (id, account, name, password) values (6, '010-5483-4792', 'test1', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
 insert into bank (id, account, name, password) values (7, '010-9394-9697', 'test2', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
+insert into bank (id, account, name, password) values (8, '010-9394-9698', 'test3', "$2y$10$c.hfcHgbhl07CdQHk7paGuS3ufujtyFMk9ZZJKx30QI2iaj6kx19.");
 
 ## admin 비밀번호는 전부 's93949697!'
 
@@ -16,7 +17,7 @@ insert into member (id, check_agree, create_date, login_date, login_id, nickname
 insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date, account) values (4, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'parkjinyoung',  '지녕쿤', '$2y$10$F26pbdd5v2A3NAplkgh9YujhqcbE7Jto2emEZg516FBwapp0XGKJC', '01030831889', 1000000, 'ROLE_ADMIN', '2023-04-07 17:45:22', '01030831889');
 insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date, account) values (5, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'parkjiyun',  '갓쥰', '$2y$10$F26pbdd5v2A3NAplkgh9YujhqcbE7Jto2emEZg516FBwapp0XGKJC', '01054834790', 1000000, 'ROLE_ADMIN', '2023-04-07 17:45:22', '01054834790');
 
-insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date, account) values (6, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'test111111',  'test111111', '$2y$10$tRo6AL3AMRBOXPTfqAFNBO06/2zGMTr5Cvkc5CoS0sjgnovVLCyRu', '01012345671', 100000, 'ROLE_USER', '2023-04-07 17:45:22',01054834792);
+insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date, account) values (6, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'test111111',  'test111111', '$2y$10$tRo6AL3AMRBOXPTfqAFNBO06/2zGMTr5Cvkc5CoS0sjgnovVLCyRu', '01012345671', 100000, 'ROLE_USER', '2023-04-07 17:45:22','01054834792');
 insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date) values (7, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'test222222',  'test222222', '$2y$10$nffYvzFk6vBB5J.8HFLjkuoaLmXvrtZ97Ivk4eAjWLXIUjvHc5YAe', '01012345672', 1000, 'ROLE_USER', '2023-04-07 17:45:22');
 insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date) values (8, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'test333333',  'test333333', '$2y$10$xsWyO3tEhyaU79pQcHw.3OPjudF4PYrhtoqD/lKd41RscMTfffz62', '01012345673', 1000, 'ROLE_USER', '2023-04-07 17:45:22');
 insert into member (id, check_agree, create_date, login_date, login_id, nickname, password ,phone_number, point, role, update_date) values (9, 1,'2023-04-07 17:45:22','2023-04-07 17:45:22', 'test444444',  'test444444', '$2y$10$JWTEL/Hlz93Q88V8WN7.9Os32EgsrC1vtHsKn/FUJ7CIwRC3ll6eC', '01012345674', 1000, 'ROLE_USER', '2023-04-07 17:45:22');

--- a/frontend/src/api/modules/patchApi.js
+++ b/frontend/src/api/modules/patchApi.js
@@ -5,6 +5,9 @@ export const patchApi = async (param) => {
     method: "patch",
     url: param.url,
     data: param.data,
+    headers: {
+      "Content-Type": "application/json",
+    },
   });
   return data;
 };

--- a/frontend/src/components/Modal/ChargePointModal.vue
+++ b/frontend/src/components/Modal/ChargePointModal.vue
@@ -4,14 +4,14 @@
       variant="text"
       color="#fff"
       class="close-btn"
-      @click="$emit('handleCancle')"
+      @click="$emit('handleCancel')"
     >
       <v-icon icon="mdi-close" />
     </v-btn>
     <v-card>
       <v-card-text>
         <v-form @submit.prevent="handleConfirm">
-          <v-text-field label="충전할 방울" />
+          <v-text-field :label="label" v-model="point" />
           <v-btn type="submit" color="subBlue" block>확인</v-btn>
         </v-form>
       </v-card-text>
@@ -20,10 +20,33 @@
 </template>
 
 <script setup>
-defineProps({
+import { patchApi } from "@/api/modules";
+import { ref } from "vue";
+const point = ref("");
+const props = defineProps({
   dialog: Boolean,
+  label: String,
+  isCharged: Boolean,
 });
-defineEmits(["handleConfirm", "handleCancle"]);
+const emits = defineEmits([
+  "handleConfirm",
+  "handleCancel",
+  "handleReturnPointResult",
+]);
+
+const handleConfirm = async () => {
+  try {
+    const response = await patchApi({
+      url: `/api/point/${props.isCharged ? "charging" : "exchanging"}`,
+      data: Number(point.value),
+    });
+    emits("handleReturnPointResult", response);
+    emits("handleCancel");
+    point.value = "";
+  } catch (error) {
+    alert(error.response.data.message);
+  }
+};
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/components/Modal/LinkAccountModal.vue
+++ b/frontend/src/components/Modal/LinkAccountModal.vue
@@ -1,0 +1,80 @@
+<template>
+  <v-dialog :v-model="dialog" width="500">
+    <v-card>
+      <!-- <v-card-title>
+          <span class="text-h5">User Profile</span>
+        </v-card-title> -->
+      <v-card-text>
+        <v-container>
+          <v-row>
+            <v-col cols="12">
+              <v-text-field label="이름" v-model="name" required></v-text-field>
+            </v-col>
+            <v-col cols="12">
+              <v-text-field
+                label="계좌번호"
+                v-model="account"
+                required
+              ></v-text-field>
+            </v-col>
+            <v-col cols="12">
+              <v-text-field
+                label="비밀번호"
+                type="password"
+                v-model="password"
+                required
+              ></v-text-field>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn color="blue-darken-1" variant="text" @click="saveAccountHandler">
+          연동하기
+        </v-btn>
+        <v-btn
+          color="blue-darken-1"
+          variant="text"
+          @click="$emit('handle-cancle-modal')"
+        >
+          닫기
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { postApi } from "@/api/modules";
+import { ref } from "vue";
+const name = ref("");
+const account = ref("");
+const password = ref("");
+
+defineProps({ dialog: Boolean });
+const emits = defineEmits(["handle-cancle-modal"]);
+
+const saveAccountHandler = async () => {
+  try {
+    await postApi({
+      url: "/api/bank/linking",
+      data: {
+        name: name.value,
+        account: account.value,
+        password: password.value,
+      },
+    });
+
+    alert("계좌 연동에 성공했습니다.");
+    name.value = "";
+    account.value = "";
+    password.value = "";
+    emits("handle-cancle-modal");
+    window.location.reload();
+  } catch (error) {
+    console.log(error);
+    alert(error.response.data.message);
+  }
+};
+</script>

--- a/frontend/src/views/MypageView.vue
+++ b/frontend/src/views/MypageView.vue
@@ -73,6 +73,30 @@
                     text="충전"
                     @click="showChargePointModal = true"
                   />
+                  <mini-button
+                    text="환전"
+                    @click="showExchangePointModal = true"
+                  />
+                </div>
+                <div class="profile_account">
+                  <v-col cols="auto">
+                    <v-btn
+                      v-if="profile.account === null"
+                      color="blue"
+                      size="large"
+                      @click="showLinkAccountModal = true"
+                      >계좌 연동하기</v-btn
+                    >
+                  </v-col>
+                  <div
+                    class="profile_account-block"
+                    v-if="profile.account !== null"
+                  >
+                    <div class="profile_account-text">내 연결 계좌</div>
+                    <div class="profile_account-info">
+                      {{ profile.account }}
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -153,7 +177,21 @@
     </v-card>
     <charge-point-modal
       v-model="showChargePointModal"
-      @handle-cancle="showChargePointModal = false"
+      @handle-cancel="showChargePointModal = false"
+      @handle-return-point-result="(result) => (profile.point = result)"
+      label="충전할 방울"
+      isCharged
+    />
+    <charge-point-modal
+      v-model="showExchangePointModal"
+      @handle-cancel="showExchangePointModal = false"
+      @handle-return-point-result="(result) => (profile.point = result)"
+      label="환전할 방울"
+    />
+    <link-account-modal
+      v-model="showLinkAccountModal"
+      @handle-cancle-modal="showLinkAccountModal = !showLinkAccountModal"
+      @handle-save-account="onHandleSaveAccount"
     />
   </content-layout>
 </template>
@@ -169,6 +207,7 @@ import InfoAlert from "@/components/Alert/InfoAlert.vue";
 import MypageProductBanner from "@/components/Banner/MypageProductBanner.vue";
 import MiniButton from "@/components/Button/MiniButton.vue";
 import ChargePointModal from "@/components/Modal/ChargePointModal.vue";
+import LinkAccountModal from "@/components/Modal/LinkAccountModal.vue";
 
 const tabList = ref([
   {
@@ -192,6 +231,8 @@ const router = useRouter();
 const display = useDisplay();
 const tab = ref(tabList.value[route.params.index].title);
 const showChargePointModal = ref(false);
+const showExchangePointModal = ref(false);
+const showLinkAccountModal = ref(false);
 const isTablet = ref(display.smAndDown);
 const profile = ref({
   rank: "mdi-umbrella-beach-outline",
@@ -257,6 +298,7 @@ const handleGetUserData = async () => {
   }
   profile.value.nickName = userData.nickname;
   profile.value.point = userData.point;
+  profile.value.account = userData.account;
   likeList.value = userData.page.content.map((data) => {
     data.isLike = true;
     return data;
@@ -462,5 +504,25 @@ const handleChangePurchasePage = () => {
 }
 .v-pagination {
   margin: 0 auto;
+}
+.profile_account {
+  .profile_account-block {
+    padding-bottom: 30px;
+    display: flex;
+    align-items: center;
+    @media (max-width: 960px) {
+      flex-direction: column;
+      font-size: 8px;
+      align-items: center;
+    }
+    .profile_account-text {
+      font-weight: bold;
+      padding-right: 10px;
+    }
+    .profile_account-info {
+      border: 1px solid lightgray;
+      padding: 7px;
+    }
+  }
 }
 </style>


### PR DESCRIPTION
## 🤷 구현한 기능
- 계좌 연동 API 연동
- 포인트 충전 API 연동
- 포인트 환전 API 연동
## 🖊️ 추가 설명

https://github.com/EASYPEACH/shroop/assets/92674967/7e1c6e7c-2396-4bdf-8b1e-aba40a09453d


마이페이지에 들어왔을 때 OnBeforeMount로 유저의 정보를 조회할 때 계좌번호도 같이 가져오게 API를 수정하였고, 계좌번호 값이 null이면 계좌연동 버튼이 나타나게 했고, 만약 계좌 정보가 있으면 그 값이 나타나게 구현했습니다. 또한 계좌연동 버튼을 눌렀을 때 알러트 창이 나타나고 새로고침을 하여 다시 프로필 정보를 조회하게 했습니다. 
## 📄 참고 사항
@Jiyun-Parkk  갓지윤