### PR TITLE
Fix: 다른 브라우저에서 로그인 시, 500 에러가 나는 현상 수정

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,10 +3,12 @@
 </template>
 
 <script setup>
+import { useRouter } from "vue-router";
 import { useApiLoading } from "@/store/useLoading";
 import api from "./api";
 
 const loadingStore = useApiLoading();
+const router = useRouter();
 
 api.interceptors.request.use(
   (config) => {
@@ -24,14 +26,14 @@ api.interceptors.request.use(
   },
   (err) => {
     loadingStore.setIsLoading(false);
-    if (err.response.status === 500) {
-      alert(
-        "서버에 문제가 생겼습니다. 새로고침을 하거나 관리자에게 문의해주세요.",
-      );
+    if (err.response.status === 403) {
+      router.go(0);
+      alert("로그아웃 되었습니다");
     }
     return Promise.reject(err);
   },
 );
+
 api.interceptors.response.use(
   (config) => {
     loadingStore.setIsLoading(false);
@@ -39,10 +41,9 @@ api.interceptors.response.use(
   },
   (err) => {
     loadingStore.setIsLoading(false);
-    if (err.response.status === 500) {
-      alert(
-        "서버에 문제가 생겼습니다. 새로고침을 하거나 관리자에게 문의해주세요.",
-      );
+    if (err.response.status === 403) {
+      router.go(0);
+      alert("로그아웃 되었습니다");
     }
     return Promise.reject(err);
   },

--- a/frontend/src/store/useCheckLogin.js
+++ b/frontend/src/store/useCheckLogin.js
@@ -3,7 +3,7 @@ import { defineStore } from "pinia";
 export const useCheckLogin = defineStore("checkLogin", {
   state: () => {
     return {
-      isLogin: true,
+      isLogin: false,
       id: 0,
       nickName: "",
     };


### PR DESCRIPTION
## 🤷 구현한 기능
다른 브라우저에서 로그인 시 로그인 페이지로 이동하도록 수정

## 🖊️ 추가 설명
notification 버튼이 이미 렌더링되어 있어 로그인 성공 여부를 나타내는 전역 변수를 제대로 못 가져오고 있는 것 같습니다
그래서 계속해서 로그인 여부 API 를 호출하고 있는 것으로 보입니다
 -> 우선 403 에러시 프론트 페이지 새로고침 하도록 수정하였습니다

## 📄 참고 사항
https://blog.sunimos.me/25


