### PR TITLE
Fix: 프로필 수정 시 이미지가 안나오는 현상 수정

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -131,7 +131,7 @@ const routes = [
       {
         path: "/phone",
         name: "PhoneAuth",
-        component: PhoneAuthView.default,
+        component: PhoneAuthView,
       },
       {
         path: "/notFound",

--- a/frontend/src/views/auth/PhoneAuthView.vue
+++ b/frontend/src/views/auth/PhoneAuthView.vue
@@ -41,7 +41,7 @@ import { postApi } from "@/api/modules";
 import { useUserStore } from "@/store/modules";
 import { useCookies } from "vue3-cookies";
 import { MainTitle } from "@/components/Title";
-import CustomTextInput from "@/components/Form/CustomTextInput.vue";
+import { CustomTextInput } from "@/components/Form";
 
 const { cookies } = useCookies();
 const router = useRouter();
@@ -55,7 +55,7 @@ const handleSubmitAuth = async () => {
     await postApi({
       url: "/api/auth/sign-up",
       data: {
-        loginId: userStore.id,
+        loginId: userStore.loginId,
         nickname: userStore.nickname,
         password: userStore.password,
         phoneNumber: userStore.phoneNumber,

--- a/frontend/src/views/mypage/MypageEditProfileView.vue
+++ b/frontend/src/views/mypage/MypageEditProfileView.vue
@@ -8,7 +8,7 @@
     >
       <div class="profile__info-imgbox">
         <div class="profile__info-img">
-          <img :src="imageThumb ? imageThumb : basicProfile" />
+          <img :src="imageThumb" />
           <label for="profile_image" class="profile__info-edit">
             <v-icon icon="mdi-camera" />
           </label>
@@ -186,11 +186,10 @@ const handleInputSignOutEvent = () => {
 const handleSubmitRegister = async () => {
   let formData = new FormData();
 
-  if (profileImgRef.value !== null) {
-    Array.from(profileImgRef.value.files).forEach((file) => {
-      formData.append("userImg", file);
-    });
-  }
+  Array.from(profileImgRef.value.files).forEach((file) => {
+    formData.append("userImg", file);
+  });
+
   multipartFormDataJson(formData, "editRequest", {
     nickname: nickname.value,
     oldPassword: oldPassword.value,


### PR DESCRIPTION
## 🤷 구현한 기능
프로필 수정 후 빈값이 저장되어 이후에 기본이미지가 미노출 되었음 
(기본이미지는 빈값이 아닌 null 일때 나오도록 구현되어 있는 상태)

## 🖊️ 추가 설명

## 📄 참고 사항
