### PR TITLE
Refactor: 모바일 환경에서의 배너 크기 조정

### DIFF
--- a/frontend/src/components/Banner/MypageProductBanner.vue
+++ b/frontend/src/components/Banner/MypageProductBanner.vue
@@ -238,7 +238,7 @@ aside {
     align-items: center;
     @media (max-width: 750px) {
       p {
-        font-size: 15px;
+        font-size: 13px;
       }
     }
 
@@ -247,9 +247,9 @@ aside {
       text-align: center;
     }
     ul {
-      font-size: 14px;
       width: 90px;
       li {
+        font-size: 13px;
         text-align: center;
       }
     }

--- a/frontend/src/components/Banner/ProductBanner.vue
+++ b/frontend/src/components/Banner/ProductBanner.vue
@@ -111,10 +111,13 @@ defineEmits(["handle-click-like"]);
 
   @media (max-width: 960px) {
     .banner__content {
+      gap: 10px;
       > div {
         width: 50%;
+        overflow: hidden;
+        text-overflow: ellipsis;
         h4 {
-          width: 60%;
+          /* width: 60%; */
           font-size: 16px;
           white-space: nowrap;
           overflow: hidden;

--- a/frontend/src/components/ProductCard.vue
+++ b/frontend/src/components/ProductCard.vue
@@ -73,6 +73,7 @@ defineEmits(["handle-click-like"]);
   padding: 10px 15px;
   font-weight: 600;
   p {
+    padding: 5px 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -13,11 +13,12 @@ import "aos/dist/aos.css";
 
 // Plugins
 import { registerPlugins } from "@/plugins";
+import AOS from "aos";
 
 import "./styles/global.style.css";
 
 const app = createApp(App);
 
 registerPlugins(app);
-
+AOS.init();
 app.mount("#app");

--- a/frontend/src/plugins/index.js
+++ b/frontend/src/plugins/index.js
@@ -9,9 +9,8 @@ import { loadFonts } from "./webfontloader";
 import vuetify from "./vuetify";
 import pinia from "../store";
 import router from "../router";
-import AOS from "aos";
 
 export function registerPlugins(app) {
   loadFonts();
-  app.use(vuetify).use(AOS.init()).use(router).use(pinia);
+  app.use(vuetify).use(router).use(pinia);
 }


### PR DESCRIPTION
## 🤷 구현한 기능
- 모바일 환경에서 배너가 다 보이지 않는 부분을 수정했습니다.
- 
## 🖊️ 추가 설명

## 📄 참고 사항

[기존]
<img width="207" alt="image" src="https://github.com/EASYPEACH/shroop/assets/72537762/87bd1a62-1b5c-4a61-9032-805c4aed6486">

[변경]
<img width="207" alt="image" src="https://github.com/EASYPEACH/shroop/assets/72537762/68d83815-87cf-4b0d-baf5-d4ec9994fd1f">
