### PR TITLE
Refactor: 비밀번호 변경 안내 타이틀을 추가한다

### DIFF
--- a/frontend/src/components/Form/PasswordInput.vue
+++ b/frontend/src/components/Form/PasswordInput.vue
@@ -3,7 +3,7 @@
     <div
       class="text-subtitle-1 text-medium-emphasis d-flex align-center justify-space-between"
     >
-      비밀번호
+      {{title}}
     </div>
     <v-text-field
       :append-inner-icon="visible ? 'mdi-eye' : 'mdi-eye-off'"
@@ -25,6 +25,7 @@ defineProps({
   modelValue: String,
   visible: Boolean,
   rules: Object,
+  title: String
 });
 defineEmits(["update:modelValue", "toggle-visible"]);
 </script>

--- a/frontend/src/views/mypage/MypageEditProfileView.vue
+++ b/frontend/src/views/mypage/MypageEditProfileView.vue
@@ -36,12 +36,14 @@
         <h4 class="profile__info-name">패스워드</h4>
         <div class="info__input-box">
           <password-input
+            title="기존 패스워드"
             class="profile__info-input"
             placeholderText="기존 패스워드"
             v-model="oldPassword"
             type="password"
           />
           <password-input
+            title="새로운 패스워드"
             class="profile__info-input"
             placeholderText="변경할 패스워드"
             v-model="newPassword"

--- a/frontend/src/views/mypage/MypageHomeView.vue
+++ b/frontend/src/views/mypage/MypageHomeView.vue
@@ -173,7 +173,7 @@ const handleGetUserData = async () => {
   profile.value.point = userData.point;
   profile.value.account = userData.account;
   profile.value.score = userData.gradeScore;
-  console.log(userData);
+  
   handleScoreToRankIcon(userData.gradeScore);
 
   likeList.value = userData.page.content.map((data) => {


### PR DESCRIPTION
## 🤷 구현한 기능
패스워드 input 의 타이틀이 비밀번호로 되어 있어서 어떻게 변경하는지 안내가 되지 않았습니다
기존 비밀번호, 새로운 비밀번호 텍스트 추가하여 방법을 안내하였습니다

## 🖊️ 추가 설명
![image](https://github.com/EASYPEACH/shroop/assets/122027452/f03efb74-7d4b-45df-ba0b-49eae9c7eed8)


## 📄 참고 사항
