### PR TITLE
Refactor: 마이페이지 구매내역 조회 페이징으로 리팩토링을 했다

### DIFF
--- a/backend/src/docs/asciidoc/transaction.adoc
+++ b/backend/src/docs/asciidoc/transaction.adoc
@@ -40,12 +40,25 @@ include::{snippets}/getBuyingCompletedForm/path-parameters.adoc[]
 include::{snippets}/getBuyingCompletedForm/http-response.adoc[]
 include::{snippets}/getBuyingCompletedForm/response-fields.adoc[]
 
+== 구매 내역 조회
+
+=== Request
+
+include::{snippets}/getBuyingHistory/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/getBuyingHistory/http-response.adoc[]
+include::{snippets}/getBuyingHistory/response-fields.adoc[]
+
 == 판매 내역 조회
 
 === Request
+
 include::{snippets}/getSellingHistory/http-request.adoc[]
 
 === Response
+
 include::{snippets}/getSellingHistory/http-response.adoc[]
 include::{snippets}/getSellingHistory/response-fields.adoc[]
 

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/TransactionHistoryController.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/controller/TransactionHistoryController.java
@@ -1,7 +1,5 @@
 package com.easypeach.shroop.modules.transaction.controller;
 
-import java.util.List;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,7 +9,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.easypeach.shroop.modules.auth.support.LoginMember;
 import com.easypeach.shroop.modules.member.domain.Member;
-import com.easypeach.shroop.modules.transaction.dto.response.HistoryResponse;
 import com.easypeach.shroop.modules.transaction.dto.response.PageResponse;
 import com.easypeach.shroop.modules.transaction.service.TransactionService;
 
@@ -21,18 +18,17 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/history")
 public class TransactionHistoryController {
 
 	private final TransactionService transactionService;
 
-	@GetMapping("/buying/history")
-	public ResponseEntity<List<HistoryResponse>> getBuyingHistory(@LoginMember Member member) {
-
-		return ResponseEntity.status(HttpStatus.OK).body(transactionService.findAllBuyingHistory(member));
+	@GetMapping("/buying")
+	public ResponseEntity<PageResponse> getBuyingHistory(@LoginMember Member member, Pageable pageable) {
+		return ResponseEntity.status(HttpStatus.OK).body(transactionService.findAllBuyingHistory(member, pageable));
 	}
 
-	@GetMapping("/selling/history")
+	@GetMapping("/selling")
 	public ResponseEntity<PageResponse> getSellingHistory(@LoginMember Member member, Pageable pageable) {
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(transactionService.findAllSellingHistory(member, pageable));

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/domain/TransactionRepository.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/domain/TransactionRepository.java
@@ -1,8 +1,9 @@
 package com.easypeach.shroop.modules.transaction.domain;
 
-import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.easypeach.shroop.modules.member.domain.Member;
@@ -14,7 +15,7 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
 
 	Optional<Transaction> findByProductId(Long productId);
 
-	List<Transaction> findAllByBuyer(Member buyer);
+	Page<Transaction> findByBuyer(Member seller, Pageable pageable);
 
 	default Transaction getByProductId(Long productId) {
 		return findByProductId(productId).orElseThrow(

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/dto/response/HistoryResponse.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/dto/response/HistoryResponse.java
@@ -3,7 +3,6 @@ package com.easypeach.shroop.modules.transaction.dto.response;
 import java.time.LocalDateTime;
 
 import com.easypeach.shroop.modules.product.domain.Product;
-import com.easypeach.shroop.modules.transaction.domain.Transaction;
 import com.easypeach.shroop.modules.transaction.domain.TransactionStatus;
 
 import lombok.AllArgsConstructor;
@@ -25,15 +24,6 @@ public class HistoryResponse {
 	private Long price;
 
 	private String productImgUrl;
-
-	public HistoryResponse(Transaction transaction) {
-		this.id = transaction.getProduct().getId();
-		this.transactionCreateDate = transaction.getCreateDate();
-		this.transactionStatus = transaction.getStatus();
-		this.title = transaction.getProduct().getTitle();
-		this.price = transaction.getProduct().getPrice();
-		this.productImgUrl = transaction.getProduct().getProductImgList().get(0).getProductImgUrl();
-	}
 
 	public HistoryResponse(Product product) {
 		if (product.getTransaction() != null) {

--- a/backend/src/main/java/com/easypeach/shroop/modules/transaction/service/TransactionService.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/transaction/service/TransactionService.java
@@ -1,7 +1,6 @@
 package com.easypeach.shroop.modules.transaction.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -164,12 +163,15 @@ public class TransactionService {
 		return transactionRepository.getByProductId(productId);
 	}
 
-	public List<HistoryResponse> findAllBuyingHistory(final Member member) {
+	public PageResponse findAllBuyingHistory(final Member member, final Pageable pageable) {
 		Member foundMember = memberService.findById(member.getId());
-		List<Transaction> transactionList = transactionRepository.findAllByBuyer(foundMember);
-		return transactionList.stream()
+		Page<Transaction> page = transactionRepository.findByBuyer(foundMember, pageable);
+		int pageCount = page.getTotalPages();
+		List<HistoryResponse> historyResponseList = page
+			.map(p -> productService.findByProductId(p.getProduct().getId()))
 			.map(HistoryResponse::new)
-			.collect(Collectors.toList());
+			.getContent();
+		return PageResponse.createPageResponse(pageCount, historyResponseList);
 	}
 
 	public PageResponse findAllSellingHistory(final Member member, final Pageable pageable) {

--- a/backend/src/main/resources/static/auth.html
+++ b/backend/src/main/resources/static/auth.html
@@ -563,7 +563,7 @@ Content-Length: 10
 <h3 id="_request_2">Request</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/auth/check?_csrf=2bf71bd3-e018-481b-96e0-c6ad7e6e5609 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/auth/check?_csrf=82515ea2-603a-4b27-bd82-ad3469aaf6b5 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
 Content-Length: 63
@@ -765,7 +765,7 @@ Content-Length: 52
 <h3 id="_request_4">Request</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/auth/sign-up?_csrf=60a44b62-6128-4e8d-bac2-e4b4bcfad530 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/auth/sign-up?_csrf=1d412410-9bee-48f4-b6a3-f3f5d0ead52e HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
 Content-Length: 193
@@ -905,7 +905,7 @@ Content-Length: 70
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-08 16:35:35 +0900
+Last updated 2023-09-07 15:17:38 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/main/resources/static/category.html
+++ b/backend/src/main/resources/static/category.html
@@ -598,7 +598,7 @@ Content-Length: 41
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-07 15:12:33 +0900
+Last updated 2023-09-06 16:57:37 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/main/resources/static/delivery.html
+++ b/backend/src/main/resources/static/delivery.html
@@ -646,7 +646,7 @@ Content-Length: 39
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-07 15:12:33 +0900
+Last updated 2023-09-07 15:17:38 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/main/resources/static/likes.html
+++ b/backend/src/main/resources/static/likes.html
@@ -558,7 +558,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-07 15:12:33 +0900
+Last updated 2023-09-06 16:57:37 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/main/resources/static/member.html
+++ b/backend/src/main/resources/static/member.html
@@ -509,9 +509,9 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 461
+Content-Length: 466
 
-{"userImg":"userImg","nickname":"nickname","point":100,"account":"50811112222","gradeScore":100,"page":{"content":[{"id":1,"productImgUrl":"productImgUrl","title":"title","price":"1,000","category":{"id":1,"name":"전자제품"},"createDate":"2023-09-08T19:25:15.59518"}],"pageable":"INSTANCE","totalPages":1,"totalElements":1,"last":true,"numberOfElements":1,"first":true,"size":1,"sort":{"unsorted":true,"sorted":false,"empty":true},"number":0,"empty":false}}</code></pre>
+{"userImg":"userImg","nickname":"nickname","point":100,"account":"50811112222","gradeScore":100,"page":{"content":[{"id":1,"productImgUrl":"productImgUrl","title":"title","price":"1,000","categoryInfo":{"id":1,"name":"전자제품"},"createDate":"2023-09-10T21:00:28.818743"}],"pageable":"INSTANCE","totalPages":1,"totalElements":1,"last":true,"numberOfElements":1,"first":true,"size":1,"sort":{"unsorted":true,"sorted":false,"empty":true},"number":0,"empty":false}}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -579,12 +579,12 @@ Content-Length: 461
 <td class="tableblock halign-left valign-top"><p class="tableblock">상품 가격</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page.content[].category.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page.content[].categoryInfo.id</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">카테고리 UID</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page.content[].category.name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page.content[].categoryInfo.name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">카테고리 이름</p></td>
 </tr>
@@ -1082,7 +1082,7 @@ Content-Length: 22
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-08 18:32:34 +0900
+Last updated 2023-09-08 21:00:01 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/main/resources/static/notification.html
+++ b/backend/src/main/resources/static/notification.html
@@ -492,7 +492,7 @@ Content-Length: 377
   "link" : "maypage/0",
   "message" : "알림 내용1",
   "checked" : true,
-  "createDate" : "2023-09-08T19:25:17.621906"
+  "createDate" : "2023-09-10T21:00:33.072179"
 }, {
   "id" : 2,
   "memberId" : 1,
@@ -500,7 +500,7 @@ Content-Length: 377
   "link" : "maypage/0",
   "message" : "알림 내용2",
   "checked" : false,
-  "createDate" : "2023-09-08T19:25:17.621906"
+  "createDate" : "2023-09-10T21:00:33.072179"
 } ]</code></pre>
 </div>
 </div>
@@ -633,7 +633,7 @@ Content-Length: 25
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-07 15:12:33 +0900
+Last updated 2023-09-07 15:17:38 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/main/resources/static/product.html
+++ b/backend/src/main/resources/static/product.html
@@ -525,13 +525,15 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 744
+Content-Length: 796
 
 {
   "id" : 1,
   "seller" : {
     "id" : 1,
-    "nickName" : "판매자"
+    "nickName" : "판매자",
+    "profileImg" : "imgUrl",
+    "gradeScore" : 10
   },
   "transactionStatus" : "PURCHASE_REQUEST",
   "title" : "중고물건 팔아요",
@@ -553,8 +555,8 @@ Content-Length: 744
   "content" : "제곧네제곧네제곧네제곧네제곧네제곧네제곧네제곧네제곧네제곧네제곧네",
   "isDefect" : false,
   "saleReason" : "안써요안써요안써요",
-  "purchaseDate" : "2023-09-08",
-  "createDate" : "2023-09-08T19:25:18.643796"
+  "purchaseDate" : "2023-09-10",
+  "createDate" : "2023-09-10T21:00:35.721724"
 }</code></pre>
 </div>
 </div>
@@ -591,6 +593,16 @@ Content-Length: 744
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>seller.nickName</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">판매자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>seller.profileImg</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">판매자 프로필 이미지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>seller.gradeScore</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">판매자 등급 점수</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>transactionStatus</code></p></td>
@@ -1135,7 +1147,7 @@ Content-Length: 321
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-07 15:12:33 +0900
+Last updated 2023-09-06 16:57:37 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/main/resources/static/report.html
+++ b/backend/src/main/resources/static/report.html
@@ -552,7 +552,7 @@ Content-Length: 52
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-07 15:12:33 +0900
+Last updated 2023-09-07 15:17:38 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/main/resources/static/return.html
+++ b/backend/src/main/resources/static/return.html
@@ -570,7 +570,7 @@ Content-Length: 59
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-08 16:35:35 +0900
+Last updated 2023-09-08 10:38:29 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/main/resources/static/transaction.html
+++ b/backend/src/main/resources/static/transaction.html
@@ -464,34 +464,40 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_response_3">Response</a></li>
 </ul>
 </li>
-<li><a href="#_판매_내역_조회">판매 내역 조회</a>
+<li><a href="#_구매_내역_조회">구매 내역 조회</a>
 <ul class="sectlevel2">
 <li><a href="#_request_4">Request</a></li>
 <li><a href="#_response_4">Response</a></li>
 </ul>
 </li>
-<li><a href="#_구매자_조회하기">구매자 조회하기</a>
+<li><a href="#_판매_내역_조회">판매 내역 조회</a>
 <ul class="sectlevel2">
 <li><a href="#_request_5">Request</a></li>
 <li><a href="#_response_5">Response</a></li>
 </ul>
 </li>
-<li><a href="#_구매_최소하기">구매 최소하기</a>
+<li><a href="#_구매자_조회하기">구매자 조회하기</a>
 <ul class="sectlevel2">
 <li><a href="#_request_6">Request</a></li>
 <li><a href="#_response_6">Response</a></li>
 </ul>
 </li>
-<li><a href="#_구매_확정하기">구매 확정하기</a>
+<li><a href="#_구매_최소하기">구매 최소하기</a>
 <ul class="sectlevel2">
 <li><a href="#_request_7">Request</a></li>
 <li><a href="#_response_7">Response</a></li>
 </ul>
 </li>
-<li><a href="#_반품_확정하기">반품 확정하기</a>
+<li><a href="#_구매_확정하기">구매 확정하기</a>
 <ul class="sectlevel2">
 <li><a href="#_request_8">Request</a></li>
 <li><a href="#_response_8">Response</a></li>
+</ul>
+</li>
+<li><a href="#_반품_확정하기">반품 확정하기</a>
+<ul class="sectlevel2">
+<li><a href="#_request_9">Request</a></li>
+<li><a href="#_response_9">Response</a></li>
 </ul>
 </li>
 </ul>
@@ -755,13 +761,13 @@ Content-Length: 246
 </div>
 </div>
 <div class="sect1">
-<h2 id="_판매_내역_조회">판매 내역 조회</h2>
+<h2 id="_구매_내역_조회">구매 내역 조회</h2>
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_request_4">Request</h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/selling/history HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/buying/history HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Host: localhost:8080</code></pre>
 </div>
@@ -846,10 +852,101 @@ Content-Length: 269
 </div>
 </div>
 <div class="sect1">
-<h2 id="_구매자_조회하기">구매자 조회하기</h2>
+<h2 id="_판매_내역_조회">판매 내역 조회</h2>
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_request_5">Request</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/selling/history HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_response_5">Response</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 269
+
+{
+  "pageCount" : 7,
+  "historyResponseList" : [ {
+    "id" : 1,
+    "transactionCreateDate" : "2000-01-01T01:01:01",
+    "transactionStatus" : "PURCHASE_REQUEST",
+    "title" : "상품 제목",
+    "price" : 100000,
+    "productImgUrl" : "상품 이미지 URL"
+  } ]
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">총 페이지 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>historyResponseList[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결제 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>historyResponseList[].transactionCreateDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">거래 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>historyResponseList[].transactionStatus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">거래 상태</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>historyResponseList[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상품 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>historyResponseList[].price</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상품 가격</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>historyResponseList[].productImgUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상품 이미지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_구매자_조회하기">구매자 조회하기</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_request_6">Request</h3>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 4. /api/buying/buyer/{productId}</caption>
 <colgroup>
@@ -878,7 +975,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_5">Response</h3>
+<h3 id="_response_6">Response</h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -933,7 +1030,7 @@ Content-Length: 112
 <h2 id="_구매_최소하기">구매 최소하기</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_request_6">Request</h3>
+<h3 id="_request_7">Request</h3>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 5. /api/buying/{productId}</caption>
 <colgroup>
@@ -961,7 +1058,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_6">Response</h3>
+<h3 id="_response_7">Response</h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1004,7 +1101,7 @@ Content-Length: 59
 <h2 id="_구매_확정하기">구매 확정하기</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_request_7">Request</h3>
+<h3 id="_request_8">Request</h3>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 6. /api/buying/confirm/{productId}</caption>
 <colgroup>
@@ -1032,7 +1129,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_7">Response</h3>
+<h3 id="_response_8">Response</h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1075,7 +1172,7 @@ Content-Length: 59
 <h2 id="_반품_확정하기">반품 확정하기</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_request_8">Request</h3>
+<h3 id="_request_9">Request</h3>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 7. /api/buying/return/confirm/{productId}</caption>
 <colgroup>
@@ -1103,7 +1200,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_response_8">Response</h3>
+<h3 id="_response_9">Response</h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1146,7 +1243,7 @@ Content-Length: 59
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-08 17:33:39 +0900
+Last updated 2023-09-10 20:54:12 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/test/java/com/easypeach/shroop/modules/transaction/controller/TransactionHistoryControllerTest.java
+++ b/backend/src/test/java/com/easypeach/shroop/modules/transaction/controller/TransactionHistoryControllerTest.java
@@ -44,35 +44,41 @@ class TransactionHistoryControllerTest extends ControllerTest {
 			PURCHASE_REQUEST, "상품 제목", 100000L,
 			"상품 이미지 URL");
 		dtoList.add(dto);
+		int pageCount = 7;
+		Page<HistoryResponse> page = new PageImpl<>(dtoList);
+		PageResponse pageResponse = PageResponse.createPageResponse(7, page.getContent());
 
-		given(transactionService.findAllBuyingHistory(any())).willReturn(dtoList);
+		given(transactionService.findAllBuyingHistory(any(), any())).willReturn(pageResponse);
 
-		mockMvc.perform(MockMvcRequestBuilders.get("/api/buying/history")
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/history/buying/")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].id").value(1L))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].transactionCreateDate")
+			.andExpect(MockMvcResultMatchers.jsonPath("$.historyResponseList[0].id").value(1L))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.historyResponseList[0].transactionCreateDate")
 				.value(time.toString()))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].transactionStatus").value(PURCHASE_REQUEST.toString()))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].title").value("상품 제목"))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].price").value(100000L))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].productImgUrl")
+			.andExpect(MockMvcResultMatchers.jsonPath("$.historyResponseList[0].transactionStatus")
+				.value(PURCHASE_REQUEST.toString()))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.historyResponseList[0].title").value("상품 제목"))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.historyResponseList[0].price").value(100000L))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.historyResponseList[0].productImgUrl")
 				.value("상품 이미지 URL"))
-			// .andDo(document("getBuyingHistory",
-			// 	// preprocessResponse(prettyPrint()),
-			// 	// responseFields(
-			// 	// 	fieldWithPath("id").description("상품 아이디"),
-			// 	// 	fieldWithPath("transactionCreateDate").description("거래 날짜"),
-			// 	// 	fieldWithPath("transactionStatus").description("거래 상태"),
-			// 	// 	fieldWithPath("title").description("상품 제목"),
-			// 	// 	fieldWithPath("price").description("상품 가격"),
-			// 	// 	fieldWithPath("productImgUrl").description("상품 이미지")
-			// 	// )))
+			.andDo(document("getBuyingHistory",
+				preprocessResponse(prettyPrint()),
+				responseFields(
+					fieldWithPath("pageCount").description("총 페이지 수"),
+					fieldWithPath("historyResponseList[].id").description("결제 아이디"),
+					fieldWithPath("historyResponseList[].transactionCreateDate").description("거래 날짜"),
+					fieldWithPath("historyResponseList[].transactionStatus").description("거래 상태"),
+					fieldWithPath("historyResponseList[].title").description("상품 제목"),
+					fieldWithPath("historyResponseList[].price").description("상품 가격"),
+					fieldWithPath("historyResponseList[].productImgUrl").description("상품 이미지")
+				)))
 			.andDo(print());
 
 	}
 
 	@Test
+	@DisplayName("판매내역 조회 테스트 코드")
 	void getSellingHistory() throws Exception {
 		List<HistoryResponse> dtoList = new ArrayList<>();
 		LocalDateTime time = LocalDateTime.of(2000, 1, 1, 1, 1, 1, 0);
@@ -85,7 +91,7 @@ class TransactionHistoryControllerTest extends ControllerTest {
 		PageResponse pageResponse = PageResponse.createPageResponse(7, page.getContent());
 		given(transactionService.findAllSellingHistory(any(), any())).willReturn(pageResponse);
 
-		mockMvc.perform(MockMvcRequestBuilders.get("/api/selling/history")
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/history/selling")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(MockMvcResultMatchers.jsonPath("$.historyResponseList[0].id").value(1L))

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,7 +11,7 @@
     <meta name="author" content="shroop" />
     <meta property="og:title" content="슈룹: 안전 중고거래 서비스" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/icons/icon-256x256.png" />
+    <meta property="og:image" content="/icons/icon-512x512.png" />
     <meta name="og:description" content="슈룹: 안전 중고거래 서비스" />
     <meta property="og:site_name" content="슈룹" />
     <meta name="theme-color" content="#ffffff" />

--- a/frontend/src/components/Banner/ProductBanner.vue
+++ b/frontend/src/components/Banner/ProductBanner.vue
@@ -29,7 +29,8 @@
           <transaction-badge
             v-if="
               product.transactionStatus !== null &&
-              product.transactionStatus !== undefined
+              product.transactionStatus !== undefined &&
+              $route.path.split('/')[1] !== 'mypage'
             "
           />
           <h4>{{ product.title }}</h4>

--- a/frontend/src/views/mypage/MyPagePurchaseListView.vue
+++ b/frontend/src/views/mypage/MyPagePurchaseListView.vue
@@ -5,25 +5,22 @@
         v-if="purchaseList.length === 0"
         title="구매내역이 없습니다"
       />
-      <li
-        v-for="product in purchaseList.slice(startIndex, endIndex)"
-        :key="product.id"
-      >
+      <li v-for="product in purchaseList" :key="product.id">
         <mypage-product-banner :product="product" isStatus />
       </li>
     </ul>
     <v-pagination
-      v-model="currentPage"
-      :length="pageCount"
+      v-model="purchasePage"
+      :length="purchasePageCount"
       :total-visible="isTablet ? 3 : 5"
-      @click="handleChangePurchasePage"
+      @click="handleGetPurchaseHistory"
     >
     </v-pagination>
   </content-layout>
 </template>
 
 <script setup>
-import { ref, onBeforeMount, computed, watch } from "vue";
+import { ref, onBeforeMount } from "vue";
 import { useDisplay } from "vuetify";
 import { getApi } from "@/api/modules";
 import { InfoAlert } from "@/components/Alert";
@@ -33,53 +30,29 @@ import ContentLayout from "@/layouts/ContentLayout.vue";
 const display = useDisplay();
 const isTablet = ref(display.smAndDown);
 
-const perPage = ref(5); // 페이지당 상품 수
-const currentPage = ref(1); // 현재 페이지
-const startIndex = ref(0); // 상품 시작 인덱스
-const endIndex = ref(perPage.value); // 상품 마지막 인덱스
-
-// 구매내역
 const purchaseList = ref([]);
+const purchasePageCount = ref(0);
+const purchasePage = ref(1);
 
 onBeforeMount(async () => {
   await handleGetPurchaseHistory();
 });
 
-// 상품 수 계산
-const productCount = computed(() => {
-  return purchaseList.value.length;
-});
-
-// 페이지 수 계산
-const pageCount = computed(() => {
-  return Math.ceil(productCount.value / perPage.value);
-});
-
-watch(purchaseList, () => {
-  currentPage.value = 1;
-  handleChangePurchasePage();
-});
-
 // 구매내역
 const handleGetPurchaseHistory = async () => {
   try {
-    const purchaseData = await getApi({ url: "/api/buying/history" });
+    const purchaseData = await getApi({
+      url: `/api/history/buying?page=${
+        purchasePage.value - 1
+      }&size=5&sort=createDate,desc`,
+    });
     if (purchaseData !== null) {
-      purchaseList.value = purchaseData;
+      purchaseList.value = purchaseData.historyResponseList;
+      purchasePageCount.value = purchaseData.pageCount;
     }
   } catch (error) {
     console.error(error);
   }
-};
-
-// 페이징 변경 핸들러
-const handleChangePurchasePage = () => {
-  startIndex.value = (currentPage.value - 1) * perPage.value;
-  endIndex.value = Math.min(
-    startIndex.value + perPage.value,
-    productCount.value,
-  );
-  window.scrollTo({ top: 0 });
 };
 </script>
 

--- a/frontend/src/views/mypage/MyPageSellListView.vue
+++ b/frontend/src/views/mypage/MyPageSellListView.vue
@@ -40,7 +40,7 @@ onBeforeMount(async () => {
 const handleGetSellHistory = async () => {
   try {
     const sellData = await getApi({
-      url: `/api/selling/history?page=${
+      url: `/api/history/selling?page=${
         sellingPage.value - 1
       }&size=5&sort=transactionCreateDate,desc`,
     });


### PR DESCRIPTION
## 🤷 구현한 기능
- 기존에 전체 리스트를 불러왔던 구매내역 조회를 paging으로 구현했다
- 페이징으로 변경한 구매내역 조회 API를 프론트 코드에 적용시켰다
- 구매내역 조회의 테스트 코드를 수정했다
- 구매내역, 판매내역 조회의 URI를 수정했다

## 🖊️ 추가 설명

## 📄 참고 사항
