### PR TITLE
Feat: 등급 점수 제한을 100점으로 제한한다

### DIFF
--- a/backend/src/main/java/com/easypeach/shroop/modules/member/domain/Member.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/domain/Member.java
@@ -120,6 +120,9 @@ public class Member {
 
 	public void addGradeScore(Long addScore) {
 		this.gradeScore += addScore;
+		if (this.gradeScore + addScore > 100) {
+			this.gradeScore = 100L;
+		}
 	}
 
 	public void updatePassword(String password) {

--- a/backend/src/main/java/com/easypeach/shroop/modules/member/domain/Member.java
+++ b/backend/src/main/java/com/easypeach/shroop/modules/member/domain/Member.java
@@ -120,9 +120,7 @@ public class Member {
 
 	public void addGradeScore(Long addScore) {
 		this.gradeScore += addScore;
-		if (this.gradeScore + addScore > 100) {
-			this.gradeScore = 100L;
-		}
+		this.gradeScore = Math.min(100L, this.gradeScore + addScore);
 	}
 
 	public void updatePassword(String password) {

--- a/backend/src/test/java/com/easypeach/shroop/modules/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/easypeach/shroop/modules/member/domain/MemberTest.java
@@ -1,0 +1,25 @@
+package com.easypeach.shroop.modules.member.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class MemberTest {
+
+	@DisplayName("등급 점수 100점 초과 시 100점으로 유지")
+	@Test
+	void gradeScoreLimitTest() {
+		Member member = Member.createMember(
+			"test123123",
+			"test123123!",
+			"test123123",
+			"01000001111",
+			Role.ROLE_USER,
+			0L);
+
+		member.addGradeScore(101L);
+
+		Assertions.assertThat(member.getGradeScore()).isEqualTo(100);
+
+	}
+}


### PR DESCRIPTION
## 🤷 구현한 기능
등급 점수 제한을 100점으로 제한한다

## 🖊️ 추가 설명

## 📄 참고 사항
