### PR TITLE
Fix: 구매자 정보보기 모달 위치 수정

### DIFF
--- a/frontend/src/components/Modal/BuyerInfoModal.vue
+++ b/frontend/src/components/Modal/BuyerInfoModal.vue
@@ -42,17 +42,19 @@ defineEmits(["handleConfirm", "handleCancle"]);
 </script>
 
 <style lang="scss" scoped>
-.close-btn {
-  font-size: 20px;
-  place-self: flex-end;
-  margin-right: -51px;
+.v-dialog {
+  .close-btn {
+    font-size: 20px;
+    place-self: flex-end;
+    margin-right: -17px;
+  }
 }
 
 .buyer-info {
-  width: 370px;
   background: rgb(var(--v-theme-surface));
   padding: 20px;
   border-radius: 20px;
+
   h4 {
     font-weight: 600;
     text-align: center;


### PR DESCRIPTION
## 🤷 구현한 기능
구매자 정보보기 모달의 위치를 정상 위치로 수정했다

## 🖊️ 추가 설명
[수정 이전]
![image](https://github.com/EASYPEACH/shroop/assets/72537762/a9fa48ad-0f14-4513-8b37-2e6408bae0e9)

[수정 이후]
![image](https://github.com/EASYPEACH/shroop/assets/72537762/44062890-af35-4fdd-8075-87208c75acb3)

## 📄 참고 사항
